### PR TITLE
Patch for #14

### DIFF
--- a/src/writing-tests-for-phpunit.rst
+++ b/src/writing-tests-for-phpunit.rst
@@ -236,12 +236,10 @@ See :numref:`writing-tests-for-phpunit.examples.MultipleDependencies.php`
          * @depends testProducerFirst
          * @depends testProducerSecond
          */
-        public function testConsumer()
+        public function testConsumer($a, $b)
         {
-            $this->assertSame(
-                ['first', 'second'],
-                func_get_args()
-            );
+            $this->assertSame('first', $a);
+            $this->assertSame('second', $b);
         }
     }
     ?>

--- a/src/writing-tests-for-phpunit.rst
+++ b/src/writing-tests-for-phpunit.rst
@@ -143,9 +143,10 @@ depends upon ``testPush()``.
 
    The return value yielded by a producer is passed "as-is" to its
    consumers by default. This means that when a producer returns an object,
-   a reference to that object is passed to the consumers. When a copy
-   should be used instead of a reference, then @depends clone
-   should be used instead of @depends.
+   a reference to that object is passed to the consumers. Instead of 
+   a reference either (a) a (deep) copy via ``@depends clone``, or (b) a
+   (normal shallow) clone (based on PHP keyword ``clone``) via
+   ``@depends shallowClone`` are possible too.
 
 To quickly localize defects, we want our attention to be focussed on
 relevant failing tests. This is why PHPUnit skips the execution of a test


### PR DESCRIPTION
See https://github.com/sebastianbergmann/phpunit-documentation-english/issues/14

- Mention `@depends shallowclone` besides `@depends clone`
- Explicitly declare (and use) test method arguments from (multiple) `@depends <test methods>`