### PR TITLE
Replace assertEquals() with assertSame()

### DIFF
--- a/src/annotations.rst
+++ b/src/annotations.rst
@@ -264,7 +264,7 @@ specify which method(s) a test method wants to test:
      */
     public function testBalanceIsInitiallyZero()
     {
-        $this->assertEquals(0, $this->ba->getBalance());
+        $this->assertSame(0, $this->ba->getBalance());
     }
 
 If provided, only the code coverage information for the specified
@@ -728,7 +728,7 @@ annotation in a method's DocBlock to mark it as a test method.
      */
     public function initialBalanceShouldBe0()
     {
-        $this->assertEquals(0, $this->ba->getBalance());
+        $this->assertSame(0, $this->ba->getBalance());
     }
 
 .. _appendixes.annotations.testdox:
@@ -752,7 +752,7 @@ The ``@testdox`` annotation can be applied to both test classes and test methods
          */
         public function balanceIsInitiallyZero()
         {
-            $this->assertEquals(0, $this->ba->getBalance());
+            $this->assertSame(0, $this->ba->getBalance());
         }
     }
 
@@ -783,7 +783,7 @@ you can define a data set using the ``@testWith`` annotation.
      */
     public function testStringLength(string $input, int $expectedLength)
     {
-        $this->assertEquals($expectedLength, strlen($input));
+        $this->assertSame($expectedLength, strlen($input));
     }
 
 .. _appendixes.annotations.ticket:

--- a/src/code-coverage-analysis.rst
+++ b/src/code-coverage-analysis.rst
@@ -216,7 +216,7 @@ shows an example.
          */
         public function testBalanceIsInitiallyZero()
         {
-            $this->assertEquals(0, $this->ba->getBalance());
+            $this->assertSame(0, $this->ba->getBalance());
         }
 
         /**
@@ -229,7 +229,7 @@ shows an example.
             }
 
             catch (BankAccountException $e) {
-                $this->assertEquals(0, $this->ba->getBalance());
+                $this->assertSame(0, $this->ba->getBalance());
 
                 return;
             }
@@ -247,7 +247,7 @@ shows an example.
             }
 
             catch (BankAccountException $e) {
-                $this->assertEquals(0, $this->ba->getBalance());
+                $this->assertSame(0, $this->ba->getBalance());
 
                 return;
             }
@@ -262,11 +262,11 @@ shows an example.
          */
         public function testDepositWithdrawMoney()
         {
-            $this->assertEquals(0, $this->ba->getBalance());
+            $this->assertSame(0, $this->ba->getBalance());
             $this->ba->depositMoney(1);
-            $this->assertEquals(1, $this->ba->getBalance());
+            $this->assertSame(1, $this->ba->getBalance());
             $this->ba->withdrawMoney(1);
-            $this->assertEquals(0, $this->ba->getBalance());
+            $this->assertSame(0, $this->ba->getBalance());
         }
     }
     ?>

--- a/src/database.rst
+++ b/src/database.rst
@@ -206,7 +206,7 @@ following way:
     {
         public function testCalculate()
         {
-            $this->assertEquals(2, 1 + 1);
+            $this->assertSame(2, 1 + 1);
         }
     }
     ?>
@@ -1340,7 +1340,7 @@ which has to be returned from the
 
            public function testGetRowCount()
            {
-               $this->assertEquals(2, $this->getConnection()->getRowCount('guestbook'));
+               $this->assertSame(2, $this->getConnection()->getRowCount('guestbook'));
            }
        }
        ?>
@@ -1379,12 +1379,12 @@ examples, but a third one:
 
         public function testAddEntry()
         {
-            $this->assertEquals(2, $this->getConnection()->getRowCount('guestbook'), "Pre-Condition");
+            $this->assertSame(2, $this->getConnection()->getRowCount('guestbook'), "Pre-Condition");
 
             $guestbook = new Guestbook();
             $guestbook->addEntry("suzy", "Hello world!");
 
-            $this->assertEquals(3, $this->getConnection()->getRowCount('guestbook'), "Inserting failed");
+            $this->assertSame(3, $this->getConnection()->getRowCount('guestbook'), "Inserting failed");
         }
     }
     ?>

--- a/src/fixtures.rst
+++ b/src/fixtures.rst
@@ -40,7 +40,7 @@ creation of the ``array`` fixture into the
 ``setUp()`` method. Finally, we remove the redundant code
 from the test methods and use the newly introduced instance variable,
 ``$this->stack``, instead of the method-local variable
-``$stack`` with the ``assertEquals()``
+``$stack`` with the ``assertSame()``
 assertion method.
 
 .. code-block:: php
@@ -67,14 +67,14 @@ assertion method.
         public function testPush()
         {
             array_push($this->stack, 'foo');
-            $this->assertEquals('foo', $this->stack[count($this->stack)-1]);
+            $this->assertSame('foo', $this->stack[count($this->stack)-1]);
             $this->assertFalse(empty($this->stack));
         }
 
         public function testPop()
         {
             array_push($this->stack, 'foo');
-            $this->assertEquals('foo', array_pop($this->stack));
+            $this->assertSame('foo', array_pop($this->stack));
             $this->assertTrue(empty($this->stack));
         }
     }

--- a/src/test-doubles.rst
+++ b/src/test-doubles.rst
@@ -113,7 +113,7 @@ the example. This leads to more readable and "fluent" code.
 
             // Calling $stub->doSomething() will now return
             // 'foo'.
-            $this->assertEquals('foo', $stub->doSomething());
+            $this->assertSame('foo', $stub->doSomething());
         }
     }
     ?>
@@ -146,7 +146,7 @@ the same best practice defaults used by ``createMock()``.
         public function testStub()
         {
             // Create a stub for the SomeClass class.
-            $stub = $this->getMockBuilder($originalClassName)
+            $stub = $this->getMockBuilder(SomeClass::class)
                          ->disableOriginalConstructor()
                          ->disableOriginalClone()
                          ->disableArgumentCloning()
@@ -159,7 +159,7 @@ the same best practice defaults used by ``createMock()``.
 
             // Calling $stub->doSomething() will now return
             // 'foo'.
-            $this->assertEquals('foo', $stub->doSomething());
+            $this->assertSame('foo', $stub->doSomething());
         }
     }
     ?>
@@ -194,10 +194,10 @@ can achieve this using ``returnArgument()`` instead of
                  ->will($this->returnArgument(0));
 
             // $stub->doSomething('foo') returns 'foo'
-            $this->assertEquals('foo', $stub->doSomething('foo'));
+            $this->assertSame('foo', $stub->doSomething('foo'));
 
             // $stub->doSomething('bar') returns 'bar'
-            $this->assertEquals('bar', $stub->doSomething('bar'));
+            $this->assertSame('bar', $stub->doSomething('bar'));
         }
     }
     ?>
@@ -264,8 +264,8 @@ an example.
 
             // $stub->doSomething() returns different values depending on
             // the provided arguments.
-            $this->assertEquals('d', $stub->doSomething('a', 'b', 'c'));
-            $this->assertEquals('h', $stub->doSomething('e', 'f', 'g'));
+            $this->assertSame('d', $stub->doSomething('a', 'b', 'c'));
+            $this->assertSame('h', $stub->doSomething('e', 'f', 'g'));
         }
     }
     ?>
@@ -296,7 +296,7 @@ result of a callback function or method. See
                  ->will($this->returnCallback('str_rot13'));
 
             // $stub->doSomething($argument) returns str_rot13($argument)
-            $this->assertEquals('fbzrguvat', $stub->doSomething('something'));
+            $this->assertSame('fbzrguvat', $stub->doSomething('something'));
         }
     }
     ?>
@@ -326,9 +326,9 @@ an example.
                  ->will($this->onConsecutiveCalls(2, 3, 5, 7));
 
             // $stub->doSomething() returns a different value each time
-            $this->assertEquals(2, $stub->doSomething());
-            $this->assertEquals(3, $stub->doSomething());
-            $this->assertEquals(5, $stub->doSomething());
+            $this->assertSame(2, $stub->doSomething());
+            $this->assertSame(3, $stub->doSomething());
+            $this->assertSame(5, $stub->doSomething());
         }
     }
     ?>

--- a/src/textui.rst
+++ b/src/textui.rst
@@ -58,7 +58,7 @@ indicate progress:
 
 PHPUnit distinguishes between *failures* and
 *errors*. A failure is a violated PHPUnit
-assertion such as a failing ``assertEquals()`` call.
+assertion such as a failing ``assertSame()`` call.
 An error is an unexpected exception or a PHP error. Sometimes
 this distinction proves useful since errors tend to be easier to fix
 than failures. If you have a big list of problems, it is best to

--- a/src/writing-tests-for-phpunit.rst
+++ b/src/writing-tests-for-phpunit.rst
@@ -27,7 +27,7 @@ with PHPUnit:
 
 #.
 
-   Inside the test methods, assertion methods such as ``assertEquals()`` (see :ref:`appendixes.assertions`) are used to assert that an actual value matches an expected value.
+   Inside the test methods, assertion methods such as ``assertSame()`` (see :ref:`appendixes.assertions`) are used to assert that an actual value matches an expected value.
 
 .. code-block:: php
     :caption: Testing array operations with PHPUnit
@@ -41,14 +41,14 @@ with PHPUnit:
         public function testPushAndPop()
         {
             $stack = [];
-            $this->assertEquals(0, count($stack));
+            $this->assertSame(0, count($stack));
 
             array_push($stack, 'foo');
-            $this->assertEquals('foo', $stack[count($stack)-1]);
-            $this->assertEquals(1, count($stack));
+            $this->assertSame('foo', $stack[count($stack)-1]);
+            $this->assertSame(1, count($stack));
 
-            $this->assertEquals('foo', array_pop($stack));
-            $this->assertEquals(0, count($stack));
+            $this->assertSame('foo', array_pop($stack));
+            $this->assertSame(0, count($stack));
         }
     }
     ?>
@@ -115,7 +115,7 @@ dependencies between test methods.
         public function testPush(array $stack)
         {
             array_push($stack, 'foo');
-            $this->assertEquals('foo', $stack[count($stack)-1]);
+            $this->assertSame('foo', $stack[count($stack)-1]);
             $this->assertNotEmpty($stack);
 
             return $stack;
@@ -126,7 +126,7 @@ dependencies between test methods.
          */
         public function testPop(array $stack)
         {
-            $this->assertEquals('foo', array_pop($stack));
+            $this->assertSame('foo', array_pop($stack));
             $this->assertEmpty($stack);
         }
     }
@@ -237,7 +237,7 @@ See :numref:`writing-tests-for-phpunit.examples.MultipleDependencies.php`
          */
         public function testConsumer()
         {
-            $this->assertEquals(
+            $this->assertSame(
                 ['first', 'second'],
                 func_get_args()
             );
@@ -287,7 +287,7 @@ of the array as its arguments.
          */
         public function testAdd($a, $b, $expected)
         {
-            $this->assertEquals($expected, $a + $b);
+            $this->assertSame($expected, $a + $b);
         }
 
         public function additionProvider()
@@ -314,7 +314,7 @@ of the array as its arguments.
     There was 1 failure:
 
     1) DataTest::testAdd with data set #3 (1, 1, 3)
-    Failed asserting that 2 matches expected 3.
+    Failed asserting that 2 is identical to 3.
 
     /home/sb/DataTest.php:9
 
@@ -338,7 +338,7 @@ Output will be more verbose as it'll contain that name of a dataset that breaks 
          */
         public function testAdd($a, $b, $expected)
         {
-            $this->assertEquals($expected, $a + $b);
+            $this->assertSame($expected, $a + $b);
         }
 
         public function additionProvider()
@@ -365,7 +365,7 @@ Output will be more verbose as it'll contain that name of a dataset that breaks 
     There was 1 failure:
 
     1) DataTest::testAdd with data set "one plus one" (1, 1, 3)
-    Failed asserting that 2 matches expected 3.
+    Failed asserting that 2 is identical to 3.
 
     /home/sb/DataTest.php:9
 
@@ -388,7 +388,7 @@ Output will be more verbose as it'll contain that name of a dataset that breaks 
          */
         public function testAdd($a, $b, $expected)
         {
-            $this->assertEquals($expected, $a + $b);
+            $this->assertSame($expected, $a + $b);
         }
 
         public function additionProvider()
@@ -410,7 +410,7 @@ Output will be more verbose as it'll contain that name of a dataset that breaks 
     There was 1 failure:
 
     1) DataTest::testAdd with data set #3 ('1', '1', '3')
-    Failed asserting that 2 matches expected '3'.
+    Failed asserting that 2 is identical to 3.
 
     /home/sb/DataTest.php:11
 
@@ -502,7 +502,7 @@ See :numref:`writing-tests-for-phpunit.data-providers.examples.DependencyAndData
          */
         public function testConsumer()
         {
-            $this->assertEquals(
+            $this->assertSame(
                 ['provider1', 'first', 'second'],
                 func_get_args()
             );
@@ -522,18 +522,17 @@ See :numref:`writing-tests-for-phpunit.data-providers.examples.DependencyAndData
     There was 1 failure:
 
     1) DependencyAndDataProviderComboTest::testConsumer with data set #1 ('provider2')
-    Failed asserting that two arrays are equal.
+    Failed asserting that two arrays are identical.
     --- Expected
     +++ Actual
     @@ @@
-    Array (
+    Array &0 (
     -    0 => 'provider1'
     +    0 => 'provider2'
-    1 => 'first'
-    2 => 'second'
+         1 => 'first'
+         2 => 'second'
     )
-
-    /home/sb/DependencyAndDataProviderComboTest.php:31
+    /home/sb/DependencyAndDataProviderComboTest.php:32
 
     FAILURES!
     Tests: 4, Assertions: 4, Failures: 1.
@@ -861,7 +860,7 @@ context as possible that can help to identify the problem.
     class ArrayDiffTest extends TestCase
     {
         public function testEquality() {
-            $this->assertEquals(
+            $this->assertSame(
                 [1, 2,  3, 4, 5, 6],
                 [1, 2, 33, 4, 5, 6]
             );
@@ -881,7 +880,7 @@ context as possible that can help to identify the problem.
     There was 1 failure:
 
     1) ArrayDiffTest::testEquality
-    Failed asserting that two arrays are equal.
+    Failed asserting that two arrays are identical.
     --- Expected
     +++ Actual
     @@ @@
@@ -916,7 +915,7 @@ and provide a few lines of context around every difference.
     class LongArrayDiffTest extends TestCase
     {
         public function testEquality() {
-            $this->assertEquals(
+            $this->assertSame(
                 [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2,  3, 4, 5, 6],
                 [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 33, 4, 5, 6]
             );
@@ -936,10 +935,12 @@ and provide a few lines of context around every difference.
     There was 1 failure:
 
     1) LongArrayDiffTest::testEquality
-    Failed asserting that two arrays are equal.
+    Failed asserting that two arrays are identical.
     --- Expected
     +++ Actual
     @@ @@
+         11 => 0
+         12 => 1
          13 => 2
     -    14 => 3
     +    14 => 33

--- a/src/writing-tests-for-phpunit.rst
+++ b/src/writing-tests-for-phpunit.rst
@@ -589,7 +589,7 @@ whether an exception is thrown by the code under test.
     There was 1 failure:
 
     1) ExceptionTest::testException
-    Expected exception InvalidArgumentException
+    Failed asserting that exception of type "InvalidArgumentException" is thrown.
 
     FAILURES!
     Tests: 1, Assertions: 1, Failures: 1.
@@ -644,7 +644,7 @@ shows an example.
     There was 1 failure:
 
     1) ExceptionTest::testException
-    Expected exception InvalidArgumentException
+    Failed asserting that exception of type "InvalidArgumentException" is thrown.
 
     FAILURES!
     Tests: 1, Assertions: 1, Failures: 1.
@@ -676,7 +676,7 @@ shown in :numref:`writing-tests-for-phpunit.exceptions.examples.ErrorTest.php`.
     class ExpectedErrorTest extends TestCase
     {
         /**
-         * @expectedException PHPUnit\Framework\Error
+         * @expectedException PHPUnit\Framework\Error\Error
          */
         public function testFailingInclude()
         {
@@ -706,7 +706,7 @@ and warnings, respectively.
    for classes that are too generic might lead to undesirable
    side-effects. Accordingly, testing for the ``Exception``
    class with ``@expectedException`` or
-   ``setExpectedException()`` is no longer permitted.
+   ``expectException()`` is no longer permitted.
 
 When testing that relies on php functions that trigger errors like
 ``fopen`` it can sometimes be useful to use error


### PR DESCRIPTION
This PR replaces `assertEquals()` with `assertSame()` where it makes sense.

Closes #3