### PR TITLE
#11: add CONTRIBUTING.md and CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,28 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic
+  addresses, without explicit permission
+* Other unethical or unprofessional conduct
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+By adopting this Code of Conduct, project maintainers commit themselves to fairly and consistently applying these principles to every aspect of managing this project. Project maintainers who do not follow or enforce the Code of Conduct may be permanently removed from the project team.
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project maintainer at sebastian@phpunit.de. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident.
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.3.0, available at [https://contributor-covenant.org/version/1/3/0/][version]
+
+[homepage]: https://contributor-covenant.org
+[version]: https://contributor-covenant.org/version/1/3/0/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing to the PHPUnit Documentation
+
+## Contributor Code of Conduct
+
+Please note that this project is released with a 
+[Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this 
+project you agree to abide by its terms.
+
+## Workflow
+
+* Fork the project.
+* Make your changes.
+* Run `make html` to make sure that the documentation can be built and looks as 
+expected
+* Send a pull request. Bonus points for topic branches.
+
+Please make sure that you have 
+[set up your user name and email address](https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup) 
+for use with Git. Strings such as `silly nick name <root@localhost>` look really 
+stupid in the commit history of a project.
+
+Pull requests for changes relating to a specific PHPUnit version of the 
+documentation must be based on that version's branch whereas changes for new
+versions of PHPUnit must be based on the `master` branch.  
+
+Due to time constraints, we are not always able to respond as quickly as we 
+would like. Please do not take delays personal and feel free to remind us if 
+you feel that we forgot to respond.
+
+## Reporting issues
+
+Please use the issue tracker of the affected language to create new tickets.
+General issues should always be reported in the issue tracker of the English
+documentation. 
+
+* [English Documentation](https://github.com/sebastianbergmann/phpunit-documentation-english/issues)
+* [Spanish Documentation](https://github.com/sebastianbergmann/phpunit-documentation-spanish/issues)
+* [French Documentation](https://github.com/sebastianbergmann/phpunit-documentation-french/issues)
+* [Brazilian Portuguese Documentation](https://github.com/sebastianbergmann/phpunit-documentation-brazilian-portuguese/issues)
+* [Japanese Documentation](https://github.com/sebastianbergmann/phpunit-documentation-japanese/issues)
+* [Simplified Chinese Documentation](https://github.com/sebastianbergmann/phpunit-documentation-chinese/issues)
+


### PR DESCRIPTION
`CONTRIBUTING.md` contains some basic information for people wanting to contribute to the documentation. This is by no means excessive, but rather a starting point. 

`CODE_OF_CONDUCT.md` has been copied from the main PHPUnit repository.