### PR TITLE
Remove an empty code block before @testWith

### DIFF
--- a/src/annotations.rst
+++ b/src/annotations.rst
@@ -762,8 +762,6 @@ The ``@testdox`` annotation can be applied to both test classes and test methods
    the ``@testdox`` annotation also activated the behaviour
    of the ``@test`` annotation.
 
-.. code-block:: php
-
 .. _appendixes.annotations.testWith:
 
 @testWith


### PR DESCRIPTION
Why is it needed?