### PR TITLE
Fix: Add cacheResult to default phpunit.xml

### DIFF
--- a/src/configuration.rst
+++ b/src/configuration.rst
@@ -22,6 +22,7 @@ be used to configure PHPUnit's core functionality.
              backupGlobals="true"
              backupStaticAttributes="false"
              <!--bootstrap="/path/to/bootstrap.php"-->
+             cacheResult="false"
              cacheTokens="false"
              colors="false"
              convertErrorsToExceptions="true"


### PR DESCRIPTION
This PR

* [x] adds `cacheResult` to default `phpunit.xml`

Related to https://github.com/sebastianbergmann/phpunit/pull/3092.