### PR TITLE
Adding reference link to installation of DbUnit

### DIFF
--- a/src/database.rst
+++ b/src/database.rst
@@ -40,7 +40,8 @@ work and get stuck by one of the following problems:
 
 The DbUnit extension considerably simplifies the setup of a database for
 testing purposes and allows you to verify the contents of a database after
-performing a series of operations.
+performing a series of operations. Installation of the DbUnit extention is 
+easy and is documented in :ref:`installation.optional-packages` 
 
 .. _database.supported-vendors-for-database-testing:
 


### PR DESCRIPTION
It took me a few tries to find out how to install the extension, I thought it would be helpful to add a link to those instructions in this section.

Updated from PR #100 to base off 7.0 branch.