### PR TITLE
Removed mapTestClassNameToCoveredClassName

### DIFF
--- a/src/configuration.rst
+++ b/src/configuration.rst
@@ -28,7 +28,6 @@ be used to configure PHPUnit's core functionality.
              convertNoticesToExceptions="true"
              convertWarningsToExceptions="true"
              forceCoversAnnotation="false"
-             mapTestClassNameToCoveredClassName="false"
              printerClass="PHPUnit\TextUI\ResultPrinter"
              <!--printerFile="/path/to/ResultPrinter.php"-->
              processIsolation="false"


### PR DESCRIPTION
Removed reference to attribute that has finally been removed in this commit:
https://github.com/sebastianbergmann/php-code-coverage/commit/25cc3d16d7f6dc2d90f125594515256ec29962fa

This attribute is also no longer covered by the XSD, resulting in the following warning:

```
- Element 'phpunit', attribute 'mapTestClassNameToCoveredClassName': The attribute 'mapTestClassNameToCoveredClassName' is not allo\
wed.
```

Thank you for your great work on PHPUnit!