### PR TITLE
Fix a minor type in writing-tests-for-phpunit

### DIFF
--- a/src/writing-tests-for-phpunit.rst
+++ b/src/writing-tests-for-phpunit.rst
@@ -249,7 +249,7 @@ See :numref:`writing-tests-for-phpunit.examples.MultipleDependencies.php`
 
     Time: 0 seconds, Memory: 3.25Mb
 
-    OK (3 tests, 3 assertions)
+    OK (3 tests, 4 assertions)
 
 .. _writing-tests-for-phpunit.data-providers:
 


### PR DESCRIPTION
In https://phpunit.readthedocs.io/en/7.4/writing-tests-for-phpunit.html
Example 2.4 has four assertions.