### PR TITLE
Change vfsStream package name to lowercase

### DIFF
--- a/src/test-doubles.rst
+++ b/src/test-doubles.rst
@@ -992,7 +992,7 @@ is a `stream wrapper <http://www.php.net/streams>`_ for a
 filesystem <http://en.wikipedia.org/wiki/Virtual_file_system>`_ that may be helpful in unit tests to mock the real
 filesystem.
 
-Simply add a dependency on ``mikey179/vfsStream`` to your
+Simply add a dependency on ``mikey179/vfsstream`` to your
 project's ``composer.json`` file if you use
 `Composer <https://getcomposer.org/>`_ to manage the
 dependencies of your project. Here is a minimal example of a
@@ -1004,7 +1004,7 @@ dependency on PHPUnit 4.6 and vfsStream:
     {
         "require-dev": {
             "phpunit/phpunit": "~4.6",
-            "mikey179/vfsStream": "~1"
+            "mikey179/vfsstream": "~1"
         }
     }
 


### PR DESCRIPTION
See https://github.com/composer/composer/releases/tag/1.8.1 - package names with uppercase characters are deprecated