### PR TITLE
Updated code examples for methods that can be overridden to avoid errors

### DIFF
--- a/src/code-coverage-analysis.rst
+++ b/src/code-coverage-analysis.rst
@@ -210,7 +210,7 @@ shows an example.
     {
         protected $ba;
 
-        protected function setUp()
+        protected function setUp(): void
         {
             $this->ba = new BankAccount;
         }

--- a/src/fixtures.rst
+++ b/src/fixtures.rst
@@ -54,7 +54,7 @@ assertion method.
     {
         protected $stack;
 
-        protected function setUp()
+        protected function setUp(): void
         {
             $this->stack = [];
         }
@@ -100,17 +100,17 @@ case class.
 
     class TemplateMethodsTest extends TestCase
     {
-        public static function setUpBeforeClass()
+        public static function setUpBeforeClass(): void
         {
             fwrite(STDOUT, __METHOD__ . "\n");
         }
 
-        protected function setUp()
+        protected function setUp(): void
         {
             fwrite(STDOUT, __METHOD__ . "\n");
         }
 
-        protected function assertPreConditions()
+        protected function assertPreConditions(): void
         {
             fwrite(STDOUT, __METHOD__ . "\n");
         }
@@ -127,25 +127,25 @@ case class.
             $this->assertTrue(false);
         }
 
-        protected function assertPostConditions()
+        protected function assertPostConditions(): void
         {
             fwrite(STDOUT, __METHOD__ . "\n");
         }
 
-        protected function tearDown()
+        protected function tearDown(): void
         {
             fwrite(STDOUT, __METHOD__ . "\n");
         }
 
-        public static function tearDownAfterClass()
+        public static function tearDownAfterClass(): void
         {
             fwrite(STDOUT, __METHOD__ . "\n");
         }
 
-        protected function onNotSuccessfulTest(Exception $e)
+        protected function onNotSuccessfulTest(Throwable $t): void
         {
             fwrite(STDOUT, __METHOD__ . "\n");
-            throw $e;
+            throw $t;
         }
     }
 
@@ -245,12 +245,12 @@ database after the last test of the test case, respectively.
     {
         protected static $dbh;
 
-        public static function setUpBeforeClass()
+        public static function setUpBeforeClass(): void
         {
             self::$dbh = new PDO('sqlite::memory:');
         }
 
-        public static function tearDownAfterClass()
+        public static function tearDownAfterClass(): void
         {
             self::$dbh = null;
         }

--- a/src/incomplete-and-skipped-tests.rst
+++ b/src/incomplete-and-skipped-tests.rst
@@ -131,7 +131,7 @@ method to skip the test if it is not.
 
     class DatabaseTest extends TestCase
     {
-        protected function setUp()
+        protected function setUp(): void
         {
             if (!extension_loaded('mysqli')) {
                 $this->markTestSkipped(

--- a/src/test-doubles.rst
+++ b/src/test-doubles.rst
@@ -1031,7 +1031,7 @@ influence (see :numref:`test-doubles.mocking-the-filesystem.examples.ExampleTest
 
     class ExampleTest extends TestCase
     {
-        protected function setUp()
+        protected function setUp(): void
         {
             if (file_exists(dirname(__FILE__) . '/id')) {
                 rmdir(dirname(__FILE__) . '/id');
@@ -1047,7 +1047,7 @@ influence (see :numref:`test-doubles.mocking-the-filesystem.examples.ExampleTest
             $this->assertTrue(file_exists(dirname(__FILE__) . '/id'));
         }
 
-        protected function tearDown()
+        protected function tearDown(): void
         {
             if (file_exists(dirname(__FILE__) . '/id')) {
                 rmdir(dirname(__FILE__) . '/id');
@@ -1082,7 +1082,7 @@ class that interacts with the filesystem.
 
     class ExampleTest extends TestCase
     {
-        public function setUp()
+        public function setUp(): void
         {
             vfsStreamWrapper::register();
             vfsStreamWrapper::setRoot(new vfsStreamDirectory('exampleDir'));


### PR DESCRIPTION
Added return value type hints to code snippets where overrideable methods such as setUp, tearDown etc. are shown.

This avoids a fatal error when overriding those methods in a test class, for example:

PHP Fatal error:  Declaration of ExampleTest::setUpBeforeClass() must be compatible with PHPUnit\Framework\TestCase::setUpBeforeClass(): void in /home/dave/tests/ExampleTest.php on line 3

Also updated where the onNotSuccessfulTest method is shown, updating the argument from an Exception to a Throwable, to match the source code.