### PR TITLE
Stop highlighting bash/shell code

### DIFF
--- a/src/assertions.rst
+++ b/src/assertions.rst
@@ -66,7 +66,7 @@ Reports an error identified by ``$message`` if ``$array`` does not have the ``$k
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit ArrayHasKeyTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -112,7 +112,7 @@ Reports an error identified by ``$message`` if ``$className::attributeName`` doe
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit ClassHasAttributeTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -158,7 +158,7 @@ Reports an error identified by ``$message`` if ``$array`` does not contains the 
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit ArraySubsetTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -209,7 +209,7 @@ Reports an error identified by ``$message`` if ``$className::attributeName`` doe
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit ClassHasStaticAttributeTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -257,7 +257,7 @@ Reports an error identified by ``$message`` if ``$needle`` is not an element of 
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit ContainsTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -298,7 +298,7 @@ If ``$ignoreCase`` is ``true``, the test will be case insensitive.
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit ContainsTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -338,7 +338,7 @@ If ``$ignoreCase`` is ``true``, the test will be case insensitive.
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit ContainsTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -388,7 +388,7 @@ Reports an error identified by ``$message`` if ``$haystack`` does not contain on
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit ContainsOnlyTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -439,7 +439,7 @@ Reports an error identified by ``$message`` if ``$haystack`` does not contain on
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit ContainsOnlyInstancesOfTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -485,7 +485,7 @@ Reports an error identified by ``$message`` if the number of elements in ``$hays
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit CountTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -531,7 +531,7 @@ Reports an error identified by ``$message`` if the directory specified by ``$dir
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit DirectoryExistsTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -577,7 +577,7 @@ Reports an error identified by ``$message`` if the directory specified by ``$dir
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit DirectoryIsReadableTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -623,7 +623,7 @@ Reports an error identified by ``$message`` if the directory specified by ``$dir
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit DirectoryIsWritableTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -671,7 +671,7 @@ Reports an error identified by ``$message`` if ``$actual`` is not empty.
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit EmptyTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -757,7 +757,7 @@ Reports an error identified by ``$message`` if the XML Structure of the DOMEleme
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit EqualXMLStructureTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -842,7 +842,7 @@ Reports an error identified by ``$message`` if the two variables ``$expected`` a
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit EqualsTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -913,7 +913,7 @@ Please read "`What Every Computer Scientist Should Know About Floating-Point Ari
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit EqualsTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -958,7 +958,7 @@ Reports an error identified by ``$message`` if the uncommented canonical form of
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit EqualsTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -1015,7 +1015,7 @@ Reports an error identified by ``$message`` if the two objects ``$expected`` and
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit EqualsTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -1063,7 +1063,7 @@ Reports an error identified by ``$message`` if the two arrays ``$expected`` and 
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit EqualsTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -1119,7 +1119,7 @@ Reports an error identified by ``$message`` if ``$condition`` is ``true``.
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit FalseTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -1165,7 +1165,7 @@ Reports an error identified by ``$message`` if the file specified by ``$expected
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit FileEqualsTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -1217,7 +1217,7 @@ Reports an error identified by ``$message`` if the file specified by ``$filename
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit FileExistsTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -1263,7 +1263,7 @@ Reports an error identified by ``$message`` if the file specified by ``$filename
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit FileIsReadableTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -1309,7 +1309,7 @@ Reports an error identified by ``$message`` if the file specified by ``$filename
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit FileIsWritableTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -1355,7 +1355,7 @@ Reports an error identified by ``$message`` if the value of ``$actual`` is not g
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit GreaterThanTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -1401,7 +1401,7 @@ Reports an error identified by ``$message`` if the value of ``$actual`` is not g
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit GreaterThanOrEqualTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -1447,7 +1447,7 @@ Reports an error identified by ``$message`` if ``$variable`` is not ``INF``.
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit InfiniteTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -1495,7 +1495,7 @@ Reports an error identified by ``$message`` if ``$actual`` is not an instance of
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit InstanceOfTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -1543,7 +1543,7 @@ Reports an error identified by ``$message`` if ``$actual`` is not of the ``$expe
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit InternalTypeTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -1589,7 +1589,7 @@ Reports an error identified by ``$message`` if the file or directory specified b
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit IsReadableTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -1635,7 +1635,7 @@ Reports an error identified by ``$message`` if the file or directory specified b
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit IsWritableTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -1681,7 +1681,7 @@ Reports an error identified by ``$message`` if the value of ``$actualFile`` does
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit JsonFileEqualsJsonFileTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -1728,7 +1728,7 @@ Reports an error identified by ``$message`` if the value of ``$actualJson`` does
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit JsonStringEqualsJsonFileTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -1776,7 +1776,7 @@ Reports an error identified by ``$message`` if the value of ``$actualJson`` does
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit JsonStringEqualsJsonStringTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -1829,7 +1829,7 @@ Reports an error identified by ``$message`` if the value of ``$actual`` is not l
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit LessThanTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -1875,7 +1875,7 @@ Reports an error identified by ``$message`` if the value of ``$actual`` is not l
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit LessThanOrEqualTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -1919,7 +1919,7 @@ Reports an error identified by ``$message`` if ``$variable`` is not ``NAN``.
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit NanTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -1965,7 +1965,7 @@ Reports an error identified by ``$message`` if ``$variable`` is not ``null``.
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit NotNullTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -2011,7 +2011,7 @@ Reports an error identified by ``$message`` if ``$object->attributeName`` does n
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit ObjectHasAttributeTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -2057,7 +2057,7 @@ Reports an error identified by ``$message`` if ``$string`` does not match the re
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit RegExpTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -2103,7 +2103,7 @@ Reports an error identified by ``$message`` if the ``$string`` does not match th
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit StringMatchesFormatTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -2199,7 +2199,7 @@ Reports an error identified by ``$message`` if the ``$string`` does not match th
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit StringMatchesFormatFileTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -2248,7 +2248,7 @@ Reports an error identified by ``$message`` if the two variables ``$expected`` a
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit SameTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -2287,7 +2287,7 @@ Reports an error identified by ``$message`` if the two variables ``$expected`` a
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit SameTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -2333,7 +2333,7 @@ Reports an error identified by ``$message`` if the ``$string`` does not end with
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit StringEndsWithTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -2379,7 +2379,7 @@ Reports an error identified by ``$message`` if the file specified by ``$expected
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit StringEqualsFileTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -2431,7 +2431,7 @@ Reports an error identified by ``$message`` if the ``$string`` does not start wi
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit StringStartsWithTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -2595,7 +2595,7 @@ Reports an error identified by ``$message`` if ``$condition`` is ``false``.
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit TrueTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -2642,7 +2642,7 @@ Reports an error identified by ``$message`` if the XML document in ``$actualFile
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit XmlFileEqualsXmlFileTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -2697,7 +2697,7 @@ Reports an error identified by ``$message`` if the XML document in ``$actualXml`
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit XmlStringEqualsXmlFileTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -2752,7 +2752,7 @@ Reports an error identified by ``$message`` if the XML document in ``$actualXml`
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit XmlStringEqualsXmlStringTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.

--- a/src/configuration.rst
+++ b/src/configuration.rst
@@ -14,7 +14,7 @@ PHPUnit
 The attributes of the ``<phpunit>`` element can
 be used to configure PHPUnit's core functionality.
 
-.. code-block:: bash
+.. code-block:: none
 
     <phpunit
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -126,7 +126,7 @@ The ``<testsuites>`` element and its
 one or more ``<testsuite>`` children can be
 used to compose a test suite out of test suites and test cases.
 
-.. code-block:: bash
+.. code-block:: none
 
     <testsuites>
       <testsuite name="My Test Suite">
@@ -143,7 +143,7 @@ can be specified. The example below will only add the
 :file:`/path/to/MyTest.php` file if the PHP version is at
 least 5.3.0.
 
-.. code-block:: bash
+.. code-block:: none
 
       <testsuites>
         <testsuite name="My Test Suite">
@@ -168,7 +168,7 @@ groups of tests marked with the ``@group`` annotation
 (documented in :ref:`appendixes.annotations.group`)
 that should (not) be run.
 
-.. code-block:: bash
+.. code-block:: none
 
     <groups>
       <include>
@@ -198,7 +198,7 @@ Whitelisting Files for Code Coverage
 The ``<filter>`` element and its children can
 be used to configure the whitelist for the code coverage reporting.
 
-.. code-block:: bash
+.. code-block:: none
 
     <filter>
       <whitelist processUncoveredFilesFromWhitelist="true">
@@ -220,7 +220,7 @@ The ``<logging>`` element and its
 ``<log>`` children can be used to configure the
 logging of the test execution.
 
-.. code-block:: bash
+.. code-block:: none
 
     <logging>
       <log type="coverage-html" target="/tmp/report" lowUpperBound="35"
@@ -297,7 +297,7 @@ The ``<listeners>`` element and its
 ``<listener>`` children can be used to attach
 additional test listeners to the test execution.
 
-.. code-block:: bash
+.. code-block:: none
 
     <listeners>
       <listener class="MyListener" file="/optional/path/to/MyListener.php">
@@ -319,7 +319,7 @@ additional test listeners to the test execution.
 The XML configuration above corresponds to attaching the
 ``$listener`` object (see below) to the test execution:
 
-.. code-block:: bash
+.. code-block:: none
 
     $listener = new MyListener(
         ['Sebastian'],
@@ -339,7 +339,7 @@ The ``<php>`` element and its children can be
 used to configure PHP settings, constants, and global variables. It can
 also be used to prepend the ``include_path``.
 
-.. code-block:: bash
+.. code-block:: none
 
     <php>
       <includePath>.</includePath>
@@ -357,7 +357,7 @@ also be used to prepend the ``include_path``.
 
 The XML configuration above corresponds to the following PHP code:
 
-.. code-block:: bash
+.. code-block:: none
 
     ini_set('foo', 'bar');
     define('foo', 'bar');

--- a/src/extending-phpunit.rst
+++ b/src/extending-phpunit.rst
@@ -303,7 +303,7 @@ and the second value is the actual one.
     $result = PHPUnit\TextUI\TestRunner::run($test);
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
 

--- a/src/fixtures.rst
+++ b/src/fixtures.rst
@@ -151,7 +151,7 @@ case class.
     }
     ?>
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit TemplateMethodsTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.

--- a/src/incomplete-and-skipped-tests.rst
+++ b/src/incomplete-and-skipped-tests.rst
@@ -72,7 +72,7 @@ An incomplete test is denoted by an ``I`` in the output
 of the PHPUnit command-line test runner, as shown in the following
 example:
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit --verbose SampleTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -151,7 +151,7 @@ A test that has been skipped is denoted by an ``S`` in
 the output of the PHPUnit command-line test runner, as shown in the
 following example:
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit --verbose DatabaseTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.

--- a/src/installation.rst
+++ b/src/installation.rst
@@ -48,13 +48,13 @@ If the `Suhosin <http://suhosin.org/>`_ extension is
 enabled, you need to allow execution of PHARs in your
 ``php.ini``:
 
-.. code-block:: bash
+.. code-block:: none
 
     suhosin.executor.include.whitelist = phar
 
 The PHPUnit PHAR can be used immediately after download:
 
-.. code-block:: bash
+.. code-block:: none
 
     $ wget https://phar.phpunit.de/phpunit-|version|.phar
     $ php phpunit-|version|.phar --version
@@ -62,7 +62,7 @@ The PHPUnit PHAR can be used immediately after download:
 
 It is a common practice to make the PHAR executable:
 
-.. code-block:: bash
+.. code-block:: none
 
     $ wget https://phar.phpunit.de/phpunit-|version|.phar
     $ chmod +x phpunit-|version|.phar
@@ -82,7 +82,7 @@ The following example details how release verification works. We start
 by downloading :file:`phpunit.phar` as well as its
 detached PGP signature :file:`phpunit.phar.asc`:
 
-.. code-block:: bash
+.. code-block:: none
 
     $ wget https://phar.phpunit.de/phpunit-|version|.phar
     $ wget https://phar.phpunit.de/phpunit-|version|.phar.asc
@@ -90,7 +90,7 @@ detached PGP signature :file:`phpunit.phar.asc`:
 We want to verify PHPUnit's PHP Archive (:file:`phpunit-|version|.phar`)
 against its detached signature (:file:`phpunit-|version|.phar.asc`):
 
-.. code-block:: bash
+.. code-block:: none
 
     $ gpg phpunit-|version|.phar.asc
     gpg: Signature made Sat 19 Jul 2014 01:28:02 PM CEST using RSA key ID 6372C20A
@@ -102,7 +102,7 @@ to retrieve the release manager's public key from a key server. One such
 server is :file:`pgp.uni-mainz.de`. The public key servers
 are linked together, so you should be able to connect to any key server.
 
-.. code-block:: bash
+.. code-block:: none
 
     $ gpg --keyserver pgp.uni-mainz.de --recv-keys 0x4AA394086372C20A
     gpg: requesting key 6372C20A from hkp server pgp.uni-mainz.de
@@ -115,7 +115,7 @@ Bergmann <sb@sebastian-bergmann.de>". However, we have no way of
 verifying this key was created by the person known as Sebastian
 Bergmann. But, let's try to verify the release signature again.
 
-.. code-block:: bash
+.. code-block:: none
 
     $ gpg phpunit-|version|.phar.asc
     gpg: Signature made Sat 19 Jul 2014 01:28:02 PM CEST using RSA key ID 6372C20A
@@ -157,7 +157,7 @@ Simply add a (development-time) dependency on
 ``composer.json`` file if you use `Composer <https://getcomposer.org/>`_ to manage the
 dependencies of your project:
 
-.. code-block:: bash
+.. code-block:: none
 
     composer require --dev phpunit/phpunit ^|version|
 

--- a/src/logging.rst
+++ b/src/logging.rst
@@ -18,7 +18,7 @@ used by the `JUnit
 task for Apache Ant <http://ant.apache.org/manual/Tasks/junit.html>`_. The following example shows the XML
 logfile generated for the tests in ``ArrayTest``:
 
-.. code-block:: bash
+.. code-block:: none
 
     <?xml version="1.0" encoding="UTF-8"?>
     <testsuites>
@@ -49,7 +49,7 @@ The following XML logfile was generated for two tests,
 of a test case class named ``FailureErrorTest`` and
 shows how failures and errors are denoted.
 
-.. code-block:: bash
+.. code-block:: none
 
     <?xml version="1.0" encoding="UTF-8"?>
     <testsuites>
@@ -97,7 +97,7 @@ The XML format for code coverage information logging produced by PHPUnit
 is loosely based upon the one used by `Clover <http://www.atlassian.com/software/clover/>`_. The following example shows the XML
 logfile generated for the tests in ``BankAccountTest``:
 
-.. code-block:: bash
+.. code-block:: none
 
     <?xml version="1.0" encoding="UTF-8"?>
     <coverage generated="1184835473" phpunit="3.6.0">

--- a/src/organizing-tests.rst
+++ b/src/organizing-tests.rst
@@ -31,7 +31,7 @@ test case classes in the :file:`tests` directory mirror the
 package and class structure of the System Under Test (SUT) in the
 :file:`src` directory:
 
-.. code-block:: bash
+.. code-block:: none
 
     src                                 tests
     `-- Currency.php                    `-- CurrencyTest.php
@@ -42,7 +42,7 @@ package and class structure of the System Under Test (SUT) in the
 To run all tests for the library we just need to point the PHPUnit
 command-line test runner to the test directory:
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit --bootstrap src/autoload.php tests
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -62,7 +62,7 @@ To run only the tests that are declared in the ``CurrencyTest``
 test case class in :file:`tests/CurrencyTest.php` we can use
 the following command:
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit --bootstrap src/autoload.php tests/CurrencyTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -76,7 +76,7 @@ the following command:
 For more fine-grained control of which tests to run we can use the
 ``--filter`` option:
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit --bootstrap src/autoload.php --filter testObjectCanBeConstructedForValidConstructorArgument tests
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.

--- a/src/textui.rst
+++ b/src/textui.rst
@@ -10,7 +10,7 @@ The PHPUnit command-line test runner can be invoked through the
 :file:`phpunit` command. The following code shows how to run
 tests with the PHPUnit command-line test runner:
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit ArrayTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -73,7 +73,7 @@ Command-Line Options
 Let's take a look at the command-line test runner's options in
 the following code:
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit --help
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -301,7 +301,7 @@ the following code:
     See :numref:`textui.examples.filter-patterns` for examples
     of valid filter patterns.
 
-    .. code-block:: shell
+    .. code-block:: none
         :caption: Filter pattern examples
         :name: textui.examples.filter-patterns
 
@@ -318,7 +318,7 @@ the following code:
     additional shortcuts that are available for matching data
     providers.
 
-    .. code-block:: shell
+    .. code-block:: none
         :caption: Filter shortcuts
         :name: textui.examples.filter-shortcuts
 
@@ -540,7 +540,7 @@ all of these tests succeed.
 Let us take a look at the agile documentation generated for a
 ``BankAccount`` class:
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit --testdox BankAccountTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.

--- a/src/writing-tests-for-phpunit.rst
+++ b/src/writing-tests-for-phpunit.rst
@@ -175,7 +175,7 @@ exploiting the dependencies between tests as shown in
         }
     }
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit --verbose DependencyFailureTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -241,7 +241,7 @@ See :numref:`writing-tests-for-phpunit.examples.MultipleDependencies.php`
         }
     }
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit --verbose MultipleDependenciesTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -297,7 +297,7 @@ of the array as its arguments.
         }
     }
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit DataTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -347,7 +347,7 @@ Output will be more verbose as it'll contain that name of a dataset that breaks 
         }
     }
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit DataTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -391,7 +391,7 @@ Output will be more verbose as it'll contain that name of a dataset that breaks 
         }
     }
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit DataTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -501,7 +501,7 @@ See :numref:`writing-tests-for-phpunit.data-providers.examples.DependencyAndData
         }
     }
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit --verbose DependencyAndDataProviderComboTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -565,7 +565,7 @@ See :numref:`writing-tests-for-phpunit.data-providers.examples.DependencyAndData
           }
        }
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit DataTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -623,7 +623,7 @@ whether an exception is thrown by the code under test.
         }
     }
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit ExceptionTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -687,7 +687,7 @@ shown in :numref:`writing-tests-for-phpunit.exceptions.examples.ErrorTest.php`.
         }
     }
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit -d error_reporting=2 ExpectedErrorTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -744,7 +744,7 @@ suppressing notices that would lead to a phpunit
         }
     }
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit ErrorSuppressionTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -798,7 +798,7 @@ test will be counted as a failure.
         }
     }
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit OutputTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -868,7 +868,7 @@ context as possible that can help to identify the problem.
         }
     }
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit ArrayDiffTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -922,7 +922,7 @@ and provide a few lines of context around every difference.
         }
     }
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit LongArrayDiffTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
@@ -982,7 +982,7 @@ functions on arrays or objects.
         }
     }
 
-.. code-block:: bash
+.. code-block:: none
 
     $ phpunit ArrayWeakComparisonTest
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.


### PR DESCRIPTION
This fixes build warnings about the "bash" and "shell" code
highlighters not being available.

Fixes #129