### PR TITLE
Improve documentation of coverage-related annotations

### DIFF
--- a/src/annotations.rst
+++ b/src/annotations.rst
@@ -255,7 +255,7 @@ For usage see :ref:`code-coverage-analysis.ignoring-code-blocks`.
 #######
 
 The ``@covers`` annotation can be used in the test code to
-specify which method(s) a test method wants to test:
+specify which parts of the code it is supposed to test:
 
 .. code-block:: php
 
@@ -267,11 +267,22 @@ specify which method(s) a test method wants to test:
         $this->assertSame(0, $this->ba->getBalance());
     }
 
-If provided, only the code coverage information for the specified
-method(s) will be considered.
+If provided, this effectively filters the code coverage report
+to include executed code from the referenced code parts only.
+
+This annotation can be added to the docblock of the test class or the individual
+test methods. The recommended way is to add the annotation to the docblock
+of the test class, not to the docblock of the test methods.
+
+When the ``forceCoversAnnotation`` configuration option in the
+:ref:`configuration file <appendixes.configuration>` is set to ``true``,
+every test method needs to have an associated ``@covers`` annotation
+(either on the test class or the individual test method).
 
 :numref:`appendixes.annotations.covers.tables.annotations` shows
 the syntax of the ``@covers`` annotation.
+The section :ref:`code-coverage-analysis.specifying-covered-parts`
+provides a longer example for using the annotation.
 
 .. rst-class:: table
 .. list-table:: Annotations for specifying which methods are covered by a test
@@ -280,25 +291,25 @@ the syntax of the ``@covers`` annotation.
 
     * - Annotation
       - Description
-    * - ``@covers ClassName::methodName``
+    * - ``@covers ClassName::methodName`` (not recommended)
       - Specifies that the annotated test method covers the specified method.
-    * - ``@covers ClassName``
+    * - ``@covers ClassName`` (recommended)
       - Specifies that the annotated test method covers all methods of a given class.
-    * - ``@covers ClassName<extended>``
-      - Specifies that the annotated test method covers all methods of a given class and its parent class(es) and interface(s).
-    * - ``@covers ClassName::<public>``
+    * - ``@covers ClassName<extended>`` (not recommended)
+      - Specifies that the annotated test method covers all methods of a given class and its parent class(es).
+    * - ``@covers ClassName::<public>`` (not recommended)
       - Specifies that the annotated test method covers all public methods of a given class.
-    * - ``@covers ClassName::<protected>``
+    * - ``@covers ClassName::<protected>`` (not recommended)
       - Specifies that the annotated test method covers all protected methods of a given class.
-    * - ``@covers ClassName::<private>``
+    * - ``@covers ClassName::<private>`` (not recommended)
       - Specifies that the annotated test method covers all private methods of a given class.
-    * - ``@covers ClassName::<!public>``
+    * - ``@covers ClassName::<!public>`` (not recommended)
       - Specifies that the annotated test method covers all methods of a given class that are not public.
-    * - ``@covers ClassName::<!protected>``
+    * - ``@covers ClassName::<!protected>`` (not recommended)
       - Specifies that the annotated test method covers all methods of a given class that are not protected.
-    * - ``@covers ClassName::<!private>``
+    * - ``@covers ClassName::<!private>`` (not recommended)
       - Specifies that the annotated test method covers all methods of a given class that are not private.
-    * - ``@covers ::functionName``
+    * - ``@covers ::functionName`` (recommended)
       - Specifies that the annotated test method covers the specified global function.
 
 .. _appendixes.annotations.coversDefaultClass:
@@ -344,7 +355,7 @@ test code to specify that no code coverage information will be
 recorded for the annotated test case.
 
 This can be used for integration testing. See
-:ref:`code-coverage-analysis.specifying-covered-methods.examples.GuestbookIntegrationTest.php`
+:ref:`code-coverage-analysis.specifying-covered-parts.examples.GuestbookIntegrationTest.php`
 for an example.
 
 The annotation can be used on the class and the method level and
@@ -696,9 +707,10 @@ example is a value object which is necessary for testing a unit of code.
         // ...
     }
 
-This annotation is especially useful in strict coverage mode where
-unintentionally covered code will cause a test to fail. See
-:ref:`risky-tests.unintentionally-covered-code` for more
+In addition to being helpful for persons reading the code,
+this annotation is useful in strict coverage mode
+where unintentionally covered code will cause a test to fail.
+See :ref:`risky-tests.unintentionally-covered-code` for more
 information regarding strict coverage mode.
 
 

--- a/src/code-coverage-analysis.rst
+++ b/src/code-coverage-analysis.rst
@@ -38,8 +38,9 @@ XML-based logfiles with code coverage information in various formats
 as text (and printed to STDOUT) and exported as PHP code for further
 processing.
 
-Please refer to :ref:`textui` for a list of commandline switches
-that control code coverage functionality as well as :ref:`appendixes.configuration.logging` for the relevant
+Please refer to :ref:`textui` for a list of command line switches
+that control code coverage functionality as well as
+:ref:`appendixes.configuration.logging` for the relevant
 configuration settings.
 
 .. _code-coverage-analysis.metrics:
@@ -115,7 +116,8 @@ Whitelisting Files
 It is mandatory to configure a *whitelist* for telling
 PHPUnit which sourcecode files to include in the code coverage report.
 This can either be done using the ``--whitelist``
-commandline option or via the configuration file (see :ref:`appendixes.configuration.whitelisting-files`).
+:ref:`command line <textui.clioptions>` option or via the
+configuration file (see :ref:`appendixes.configuration.whitelisting-files`).
 
 The ``addUncoveredFilesFromWhitelist`` and ``processUncoveredFilesFromWhitelist`` configuration settings are available to configure how the whitelist is used:
 
@@ -186,22 +188,33 @@ The ignored lines of code (marked as ignored using the annotations)
 are counted as executed (if they are executable) and will not be
 highlighted.
 
-.. _code-coverage-analysis.specifying-covered-methods:
+.. _code-coverage-analysis.specifying-covered-parts:
 
-Specifying Covered Methods
-##########################
+Specifying Covered Code Parts
+#############################
 
-The ``@covers`` annotation (see
-:ref:`appendixes.annotations.covers.tables.annotations`) can be
-used in the test code to specify which method(s) a test method wants to
-test. If provided, only the code coverage information for the specified
-method(s) will be considered.
-:numref:`code-coverage-analysis.specifying-covered-methods.examples.BankAccountTest.php`
+The ``@covers`` annotation (see the
+:ref:`annotaction documentation <appendixes.annotations.covers.tables.annotations>`)
+can be used in the test code to specify which code parts a test class
+(or test method) wants to test. If provided, this effectively filters the
+code coverage report to include executed code from the referenced code parts only.
+:numref:`code-coverage-analysis.specifying-covered-parts.examples.BankAccountTest.php`
 shows an example.
+
+
+.. admonition:: Note
+
+    If a method is specificed with the ``@covers`` annotation, only the
+    referenced method will be considered as covered, but not methods called
+    by this method.
+    Hence, when a covered method is refactored using the *extract method*
+    refactoring, corresponding ``@covers`` annotations need to be added.
+    This is the reason it is recommended to use this annotation with class scope,
+    not with method scope.
 
 .. code-block:: php
     :caption: Tests that specify which method they want to cover
-    :name: code-coverage-analysis.specifying-covered-methods.examples.BankAccountTest.php
+    :name: code-coverage-analysis.specifying-covered-parts.examples.BankAccountTest.php
 
     <?php
     use PHPUnit\Framework\TestCase;
@@ -284,7 +297,7 @@ generate code coverage with unit tests.
 
 .. code-block:: php
     :caption: A test that specifies that no method should be covered
-    :name: code-coverage-analysis.specifying-covered-methods.examples.GuestbookIntegrationTest.php
+    :name: code-coverage-analysis.specifying-covered-parts.examples.GuestbookIntegrationTest.php
 
     <?php
     use PHPUnit\DbUnit\TestCase

--- a/src/risky-tests.rst
+++ b/src/risky-tests.rst
@@ -16,9 +16,9 @@ Useless Tests
 
 PHPUnit is by default strict about tests that do not test anything. This check
 can be disabled by using the ``--dont-report-useless-tests``
-option on the commandline or by setting
+option on the :ref:`command line <textui.clioptions>` or by setting
 ``beStrictAboutTestsThatDoNotTestAnything="false"`` in
-PHPUnit's XML configuration file.
+PHPUnit's :ref:`configuration file <appendixes.configuration>`.
 
 A test that does not perform an assertion will be marked as risky
 when this check is enabled. Expectations on mock objects
@@ -31,12 +31,14 @@ Unintentionally Covered Code
 
 PHPUnit can be strict about unintentionally covered code. This check
 can be enabled by using the ``--strict-coverage`` option on
-the commandline or by setting
+the :ref:`command line <textui.clioptions>` or by setting
 ``beStrictAboutCoversAnnotation="true"`` in PHPUnit's
-XML configuration file.
+:ref:`configuration file <appendixes.configuration>`.
 
-A test that is annotated with @covers and executes code that
-is not listed using a @covers or @uses
+A test that is annotated with
+:ref:`@covers <appendixes.annotations.covers>` and executes code that
+is not listed using a :ref:`@covers <appendixes.annotations.covers>`
+or :ref:`@uses <appendixes.annotations.uses>`
 annotation will be marked as risky when this check is enabled.
 
 .. _risky-tests.output-during-test-execution:
@@ -46,9 +48,9 @@ Output During Test Execution
 
 PHPUnit can be strict about output during tests. This check can be enabled
 by using the ``--disallow-test-output`` option on the
-commandline or by setting
-``beStrictAboutOutputDuringTests="true"`` in PHPUnit's XML
-configuration file.
+:ref:`command line <textui.clioptions>` or by setting
+``beStrictAboutOutputDuringTests="true"`` in PHPUnit's
+:ref:`configuration file <appendixes.configuration>`.
 
 A test that emits output, for instance by invoking print in
 either the test code or the tested code, will be marked as risky when this
@@ -63,24 +65,24 @@ A time limit can be enforced for the execution of a test if the
 ``PHP_Invoker`` package is installed and the
 ``pcntl`` extension is available. The enforcing of this
 time limit can be enabled by using the
-``--enforce-time-limit`` option on the commandline or by
-setting ``enforceTimeLimit="true"`` in PHPUnit's XML
-configuration file.
+``--enforce-time-limit`` option on the :ref:`command line <textui.clioptions>`
+or by setting ``enforceTimeLimit="true"`` in PHPUnit's
+:ref:`configuration file <appendixes.configuration>`.
 
 A test annotated with ``@large`` will fail if it takes
 longer than 60 seconds to execute. This timeout is configurable via the
-``timeoutForLargeTests`` attribute in the XML
-configuration file.
+``timeoutForLargeTests`` attribute in the
+:ref:`configuration file <appendixes.configuration>`.
 
 A test annotated with ``@medium`` will fail if it takes
 longer than 10 seconds to execute. This timeout is configurable via the
-``timeoutForMediumTests`` attribute in the XML
-configuration file.
+``timeoutForMediumTests`` attribute in the
+configuration :ref:`configuration file <appendixes.configuration>`.
 
 A test annotated with ``@small`` will fail if it takes longer than
 1 second to execute. This timeout is configurable via the
-``timeoutForSmallTests`` attribute in the XML configuration
-file.
+``timeoutForSmallTests`` attribute in the
+:ref:`configuration file <appendixes.configuration>`.
 
 .. admonition:: Note
 
@@ -95,8 +97,8 @@ Global State Manipulation
 
 PHPUnit can be strict about tests that manipulate global state. This check
 can be enabled by using the ``--strict-global-state``
-option on the commandline or by setting
+option on the :ref:`command line <textui.clioptions>` or by setting
 ``beStrictAboutChangesToGlobalState="true"`` in PHPUnit's
-XML configuration file.
+:ref:`configuration file <appendixes.configuration>`.
 
 


### PR DESCRIPTION
- cross-reference the different parts with each other
- document the recommended usages of the `@covers` annotation
- stop mentioning that there can be coverage for interfaces
  (as this is not possible)
- recommend to put the `@covers` annotation on test classes,
  not on test methods, and to cover on the class level
- make it clearer that the `@covers` annotation acts as a filter