### PR TITLE
Add examples for @covers/@uses with class scope

### DIFF
--- a/src/annotations.rst
+++ b/src/annotations.rst
@@ -260,7 +260,7 @@ specify which parts of the code it is supposed to test:
 .. code-block:: php
 
     /**
-     * @covers BankAccount::getBalance
+     * @covers BankAccount
      */
     public function testBalanceIsInitiallyZero()
     {
@@ -286,7 +286,7 @@ every test method needs to have an associated ``@covers`` annotation
 :numref:`appendixes.annotations.covers.tables.annotations` shows
 the syntax of the ``@covers`` annotation.
 The section :ref:`code-coverage-analysis.specifying-covered-parts`
-provides a longer example for using the annotation.
+provides longer examples for using the annotation.
 
 .. rst-class:: table
 .. list-table:: Annotations for specifying which methods are covered by a test
@@ -703,13 +703,16 @@ example is a value object which is necessary for testing a unit of code.
 .. code-block:: php
 
     /**
-     * @covers BankAccount::deposit
+     * @covers BankAccount
      * @uses   Money
      */
     public function testMoneyCanBeDepositedInAccount()
     {
         // ...
     }
+
+:numref:`code-coverage-analysis.specifying-covered-parts.examples.InvoiceTest.php`
+shows another example.
 
 In addition to being helpful for persons reading the code,
 this annotation is useful in strict coverage mode

--- a/src/code-coverage-analysis.rst
+++ b/src/code-coverage-analysis.rst
@@ -198,7 +198,7 @@ The ``@covers`` annotation (see the
 can be used in the test code to specify which code parts a test class
 (or test method) wants to test. If provided, this effectively filters the
 code coverage report to include executed code from the referenced code parts only.
-:numref:`code-coverage-analysis.specifying-covered-parts.examples.BankAccountTest.php`
+:numref:`code-coverage-analysis.specifying-covered-parts.examples.InvoiceTest.php`
 shows an example.
 
 
@@ -211,6 +211,33 @@ shows an example.
     refactoring, corresponding ``@covers`` annotations need to be added.
     This is the reason it is recommended to use this annotation with class scope,
     not with method scope.
+
+.. code-block:: php
+    :caption: Test class that specifies which class it wants to cover
+    :name: code-coverage-analysis.specifying-covered-parts.examples.InvoiceTest.php
+
+    <?php
+    use PHPUnit\Framework\TestCase;
+
+    /**
+     * @covers Invoice
+     * @uses Money
+     */
+    class InvoiceTest extends TestCase
+    {
+        protected $subject;
+
+        protected function setUp(): void
+        {
+            $this->subject = new Invoice();
+        }
+
+        public function testAmountInitiallyIsEmpty()
+        {
+            $this->assertEquals(new Money(), $this->subject->getAmount);
+        }
+    }
+    ?>
 
 .. code-block:: php
     :caption: Tests that specify which method they want to cover


### PR DESCRIPTION
The recommended usage of the `@covers` annotation is the
class scope. The documentation should reflect that.