### PR TITLE
Enhancement: Allow using duration option

### DIFF
--- a/src/textui.rst
+++ b/src/textui.rst
@@ -157,7 +157,7 @@ the following code:
       --printer <printer>         TestListener implementation to use
 
       --resolve-dependencies      Resolve dependencies between tests
-      --order-by=<order>          Run tests in order: default|reverse|random|defects|depends
+      --order-by=<order>          Run tests in order: default|defects|duration|no-depends|random|reverse
       --random-order-seed=<N>     Use a specific random seed <N> for random order
       --cache-result              Write run result to cache to enable ordering tests defects-first
 


### PR DESCRIPTION
This PR

* [x] adjusts the documentation related to using `duration` as value for the `--order-by` option

Related to https://github.com/sebastianbergmann/phpunit/pull/3682.