### PR TITLE
Add documentation on how to configure PHPUnit extensions

### DIFF
--- a/src/configuration.rst
+++ b/src/configuration.rst
@@ -357,6 +357,44 @@ such an extension.
           </extensions>
       </phpunit>
 
+
+.. _appendixes.configuration.phpunit.extensions.extension.arguments:
+
+Configuring TestRunner Extensions
+---------------------------------
+
+The ``<arguments>`` element can be used to configure a single ``<extension>``.
+
+Accepts a list of elements of types, which are then used to configure individual extensions.
+
+- ``<boolean>``
+- ``<integer>``
+- ``<string>``
+- ``<double>`` (float)
+- ``<array>``
+- ``<object>``
+
+.. code-block:: xml
+
+    <extension class="Vendor\MyExtension">
+        <arguments>
+            <integer>1</integer>
+            <integer>2</integer>
+            <integer>3</integer>
+            <string>hello world</string>
+            <boolean>true</boolean>
+            <double>1.23</double>
+            <array>
+                <element>value1</element>
+                <element>value2</element>
+            </array>
+            <object class="Vendor\MyPhpClass">
+                <string>constructor arg 1</string>
+                <string>constructor arg 2</string>
+            </object>
+        </arguments>
+    </extension>
+
 .. _appendixes.configuration.php-ini-constants-variables:
 
 Setting PHP INI settings, Constants and Global Variables

--- a/src/extending-phpunit.rst
+++ b/src/extending-phpunit.rst
@@ -171,3 +171,81 @@ for an extension implementing ``BeforeFirstTestHook`` and ``AfterLastTestHook``:
             // called after the last test has been run
         }
     }
+
+Configuring extensions
+----------------------
+
+You can configure PHPUnit extensions, assuming the extension accepts
+configuration values.
+
+:numref:`extending-phpunit.examples.TestRunnerConfigurableExtension` shows an
+example how to make an extension configurable, by adding an ``__constructor()``
+definition to the extension class:
+
+.. code-block:: php
+    :caption: TestRunner Extension with constructor
+    :name: extending-phpunit.examples.TestRunnerConfigurableExtension
+
+    <?php declare(strict_types=1);
+    namespace Vendor;
+
+    use PHPUnit\Runner\BeforeFirstTestHook;
+
+    final class MyConfigurableExtension implements BeforeFirstTestHook
+    {
+        protected $config_value_1 = null;
+
+        protected $config_value_2 = null;
+
+        public function __construct(...$configuration)
+        {
+            $config_1 = isset($configuration[0]) ? (string) $configuration[0] : null;
+            $config_2 = isset($configuration[1]) ? (int) $configuration[1] : null;
+
+            $this->config_value_1 = $config_1;
+            $this->config_value_2 = $config_2;
+        }
+
+        public function executeBeforeFirstTest(): void
+        {
+            if ($this->config_value_1 !== null) {
+                echo 'Testing with configuration value: ' . $this->config_value_1;
+            }
+        }
+
+        public function executeAfterLastTest(): void
+        {
+            if ($this->config_value_2 !== null && $this->config_value_2 > 10) {
+                echo 'Second config value is OK!';
+            }
+        }
+    }
+
+The configuration values are passed to the extension constructor without type
+checks, meaning you need to handle type and value checks yourself inside the
+extension constructor.
+
+To input configuration to the extension via XML, the XML configuration file's
+``extensions`` section needs to be updated to have configuration values, as
+shown in
+:numref:`extending-phpunit.examples.TestRunnerConfigurableExtensionConfig`:
+
+.. code-block:: xml
+    :caption: TestRunner Extension configuration
+    :name: extending-phpunit.examples.TestRunnerConfigurableExtensionConfig
+
+    <extensions>
+        <extension class="Vendor\MyUnconfigurableExtension" />
+        <extension class="Vendor\MyConfigurableExtension">
+            <arguments>
+                <string>Hello world!</string>
+                <int>15</int>
+            </arguments>
+        </extension>
+    </extensions>
+
+See :ref:`appendixes.configuration.phpunit.extensions.extension.arguments` for
+details on how to use the ``arguments`` configuration.
+
+Remember: all configuration is optional, so make sure your extension has sane
+defaults in place, or that it disables itself in case configuration is missing.


### PR DESCRIPTION
Add notes about the `arguments` config, and add an example on how to
make extension classes configurable via `__constructor` injection.

This feature landed in 7.2 as far as I can tell, so this PR targets that branch.

Let me know if there are any kinds of errors or sources of confusion which should be fixed.