### PR TITLE
[7.5] Add documentation on how to configure PHPUnit extensions

### DIFF
--- a/src/configuration.rst
+++ b/src/configuration.rst
@@ -619,6 +619,53 @@ Parent element: ``<extensions>``
         <extension class="Vendor\MyExtension"/>
     </extensions>
 
+.. _appendixes.configuration.phpunit.extensions.extension.arguments:
+
+The ``<arguments>`` Element
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Parent element: ``<extension>``
+
+The ``<arguments>`` element can be used to configure a single ``<extension>``.
+
+Accepts a list of elements of types, which are then used to configure individual
+extensions. The arguments are passed to the extension class' ``__constructor``
+method in the order they are defined in the configuration.
+
+Available types:
+
+- ``<boolean>``
+- ``<integer>``
+- ``<string>``
+- ``<double>`` (float)
+- ``<array>``
+- ``<object>``
+
+.. code-block:: xml
+
+    <extension class="Vendor\MyExtension">
+        <arguments>
+            <integer>1</integer>
+            <integer>2</integer>
+            <integer>3</integer>
+            <string>hello world</string>
+            <boolean>true</boolean>
+            <double>1.23</double>
+            <array>
+                <element index="0">
+                    <string>value1</string>
+                </element>
+                <element index="1">
+                    <string>value2</string>
+                </element>
+            </array>
+            <object class="Vendor\MyPhpClass">
+                <string>constructor arg 1</string>
+                <string>constructor arg 2</string>
+            </object>
+        </arguments>
+    </extension>
+
 .. _appendixes.configuration.phpunit.logging:
 
 The ``<logging>`` Element

--- a/src/extending-phpunit.rst
+++ b/src/extending-phpunit.rst
@@ -172,3 +172,76 @@ for an extension implementing ``BeforeFirstTestHook`` and ``AfterLastTestHook``:
             // called after the last test has been run
         }
     }
+
+Configuring extensions
+----------------------
+
+You can configure PHPUnit extensions, assuming the extension accepts
+configuration values.
+
+:numref:`extending-phpunit.examples.TestRunnerConfigurableExtension` shows an
+example how to make an extension configurable, by adding an ``__constructor()``
+definition to the extension class:
+
+.. code-block:: php
+    :caption: TestRunner Extension with constructor
+    :name: extending-phpunit.examples.TestRunnerConfigurableExtension
+
+    <?php declare(strict_types=1);
+    namespace Vendor;
+
+    use PHPUnit\Runner\BeforeFirstTestHook;
+    use PHPUnit\Runner\AfterLastTestHook;
+
+    final class MyConfigurableExtension implements BeforeFirstTestHook, AfterLastTestHook
+    {
+        protected $config_value_1 = '';
+
+        protected $config_value_2 = 0;
+
+        public function __construct(string $value1 = '', int $value2 = 0)
+        {
+            $this->config_value_1 = $config_1;
+            $this->config_value_2 = $config_2;
+        }
+
+        public function executeBeforeFirstTest(): void
+        {
+            if (strlen($this-config_value_1) {
+                echo 'Testing with configuration value: ' . $this->config_value_1;
+            }
+        }
+
+        public function executeAfterLastTest(): void
+        {
+            if ($this->config_value_2 > 10) {
+                echo 'Second config value is OK!';
+            }
+        }
+    }
+
+To input configuration to the extension via XML, the XML configuration file's
+``extensions`` section needs to be updated to have configuration values, as
+shown in
+:numref:`extending-phpunit.examples.TestRunnerConfigurableExtensionConfig`:
+
+.. code-block:: xml
+    :caption: TestRunner Extension configuration
+    :name: extending-phpunit.examples.TestRunnerConfigurableExtensionConfig
+
+    <extensions>
+        <extension class="Vendor\MyUnconfigurableExtension" />
+        <extension class="Vendor\MyConfigurableExtension">
+            <arguments>
+                <string>Hello world!</string>
+                <int>15</int>
+            </arguments>
+        </extension>
+    </extensions>
+
+See :ref:`appendixes.configuration.phpunit.extensions.extension.arguments` for
+details on how to use the ``arguments`` configuration.
+
+Remember: all configuration is optional, so make sure your extension either has
+sane defaults in place, or that it disables itself in case configuration is
+missing.


### PR DESCRIPTION
Add notes about the `arguments` config, and add an example on how to
make extension classes configurable via `__constructor` injection.

This PR targets documentation for PHPUnit version 7.5 and up.