### PR TITLE
Fixed static methods being called dynamically

### DIFF
--- a/src/annotations.rst
+++ b/src/annotations.rst
@@ -290,7 +290,7 @@ specify which parts of the code it is supposed to test:
      */
     public function testBalanceIsInitiallyZero()
     {
-        $this->assertSame(0, $this->ba->getBalance());
+        self::assertSame(0, $this->ba->getBalance());
     }
 
 If provided, this effectively filters the code coverage report
@@ -634,7 +634,7 @@ annotation in a method's DocBlock to mark it as a test method.
      */
     public function initialBalanceShouldBe0()
     {
-        $this->assertSame(0, $this->ba->getBalance());
+        self::assertSame(0, $this->ba->getBalance());
     }
 
 .. _appendixes.annotations.testdox:
@@ -659,7 +659,7 @@ The ``@testdox`` annotation can be applied to both test classes and test methods
          */
         public function balanceIsInitiallyZero()
         {
-            $this->assertSame(0, $this->ba->getBalance());
+            self::assertSame(0, $this->ba->getBalance());
         }
     }
 
@@ -679,7 +679,7 @@ When using the ``@testdox`` annotation at method level with a ``@dataProvider`` 
      */
     public function testAdd($a, $b, $expected)
     {
-        $this->assertSame($expected, $a + $b);
+        self::assertSame($expected, $a + $b);
     }
 
     public function additionProvider()
@@ -718,7 +718,7 @@ more about passing a set of data to a test.
      */
     public function testStringLength(string $input, int $expectedLength)
     {
-        $this->assertSame($expectedLength, strlen($input));
+        self::assertSame($expectedLength, strlen($input));
     }
 
 An object representation in JSON will be converted into an associative array.
@@ -733,7 +733,7 @@ An object representation in JSON will be converted into an associative array.
      */
     public function testArrayKeys($array, $keys)
     {
-        $this->assertSame($keys, array_keys($array));
+        self::assertSame($keys, array_keys($array));
     }
 
 .. _appendixes.annotations.ticket:

--- a/src/assertions.rst
+++ b/src/assertions.rst
@@ -18,7 +18,7 @@ PHPUnit's assertions are implemented in ``PHPUnit\Framework\Assert``.
 
 The assertion methods are declared static and can be invoked
 from any context using ``PHPUnit\Framework\Assert::assertTrue()``,
-for instance, or using ``$this->assertTrue()`` or ``self::assertTrue()``,
+for instance, or using ``self::assertTrue()`` or ``self::assertTrue()``,
 for instance, in a class that extends ``PHPUnit\Framework\TestCase``.
 
 In fact, you can even use global function wrappers such as ``assertTrue()`` in
@@ -27,17 +27,17 @@ when you (manually) include the :file:`src/Framework/Assert/Functions.php`
 sourcecode file that comes with PHPUnit.
 
 A common question, especially from developers new to PHPUnit, is whether
-using ``$this->assertTrue()`` or ``self::assertTrue()``,
+using ``self::assertTrue()`` or ``self::assertTrue()``,
 for instance, is "the right way" to invoke an assertion. The short answer
 is: there is no right way. And there is no wrong way, either. It is a
 matter of personal preference.
 
-For most people it just "feels right" to use ``$this->assertTrue()``
+For most people it just "feels right" to use ``self::assertTrue()``
 because the test method is invoked on a test object. The fact that the
 assertion methods are declared static allows for (re)using
 them outside the scope of a test object. Lastly, the global function
 wrappers allow developers to type less characters (``assertTrue()`` instead
-of ``$this->assertTrue()`` or ``self::assertTrue()``).
+of ``self::assertTrue()`` or ``self::assertTrue()``).
 
 .. _appendixes.assertions.assertArrayHasKey:
 
@@ -61,7 +61,7 @@ Reports an error identified by ``$message`` if ``$array`` does not have the ``$k
     {
         public function testFailure()
         {
-            $this->assertArrayHasKey('foo', ['bar' => 'baz']);
+            self::assertArrayHasKey('foo', ['bar' => 'baz']);
         }
     }
 
@@ -106,7 +106,7 @@ Reports an error identified by ``$message`` if ``$className::attributeName`` doe
     {
         public function testFailure()
         {
-            $this->assertClassHasAttribute('foo', stdClass::class);
+            self::assertClassHasAttribute('foo', stdClass::class);
         }
     }
 
@@ -151,7 +151,7 @@ Reports an error identified by ``$message`` if ``$array`` does not contains the 
     {
         public function testFailure()
         {
-            $this->assertArraySubset(['config' => ['key-a', 'key-b']], ['config' => ['key-a']]);
+            self::assertArraySubset(['config' => ['key-a', 'key-b']], ['config' => ['key-a']]);
         }
     }
 
@@ -201,7 +201,7 @@ Reports an error identified by ``$message`` if ``$className::attributeName`` doe
     {
         public function testFailure()
         {
-            $this->assertClassHasStaticAttribute('foo', stdClass::class);
+            self::assertClassHasStaticAttribute('foo', stdClass::class);
         }
     }
 
@@ -246,7 +246,7 @@ Reports an error identified by ``$message`` if ``$needle`` is not an element of 
     {
         public function testFailure()
         {
-            $this->assertContains(4, [1, 2, 3]);
+            self::assertContains(4, [1, 2, 3]);
         }
     }
 
@@ -289,7 +289,7 @@ Reports an error identified by ``$message`` if ``$needle`` is not a substring of
     {
         public function testFailure()
         {
-            $this->assertStringContainsString('foo', 'bar');
+            self::assertStringContainsString('foo', 'bar');
         }
     }
 
@@ -334,7 +334,7 @@ Differences in casing are ignored when ``$needle`` is searched for in ``$haystac
     {
         public function testFailure()
         {
-            $this->assertStringContainsStringIgnoringCase('foo', 'bar');
+            self::assertStringContainsStringIgnoringCase('foo', 'bar');
         }
     }
 
@@ -381,7 +381,7 @@ Reports an error identified by ``$message`` if ``$haystack`` does not contain on
     {
         public function testFailure()
         {
-            $this->assertContainsOnly('string', ['1', '2', 3]);
+            self::assertContainsOnly('string', ['1', '2', 3]);
         }
     }
 
@@ -428,7 +428,7 @@ Reports an error identified by ``$message`` if ``$haystack`` does not contain on
     {
         public function testFailure()
         {
-            $this->assertContainsOnlyInstancesOf(
+            self::assertContainsOnlyInstancesOf(
                 Foo::class,
                 [new Foo, new Bar, new Foo]
             );
@@ -476,7 +476,7 @@ Reports an error identified by ``$message`` if the number of elements in ``$hays
     {
         public function testFailure()
         {
-            $this->assertCount(0, ['foo']);
+            self::assertCount(0, ['foo']);
         }
     }
 
@@ -521,7 +521,7 @@ Reports an error identified by ``$message`` if the directory specified by ``$dir
     {
         public function testFailure()
         {
-            $this->assertDirectoryExists('/path/to/directory');
+            self::assertDirectoryExists('/path/to/directory');
         }
     }
 
@@ -566,7 +566,7 @@ Reports an error identified by ``$message`` if the directory specified by ``$dir
     {
         public function testFailure()
         {
-            $this->assertDirectoryIsReadable('/path/to/directory');
+            self::assertDirectoryIsReadable('/path/to/directory');
         }
     }
 
@@ -611,7 +611,7 @@ Reports an error identified by ``$message`` if the directory specified by ``$dir
     {
         public function testFailure()
         {
-            $this->assertDirectoryIsWritable('/path/to/directory');
+            self::assertDirectoryIsWritable('/path/to/directory');
         }
     }
 
@@ -656,7 +656,7 @@ Reports an error identified by ``$message`` if ``$actual`` is not empty.
     {
         public function testFailure()
         {
-            $this->assertEmpty(['foo']);
+            self::assertEmpty(['foo']);
         }
     }
 
@@ -702,7 +702,7 @@ Reports an error identified by ``$message`` if the XML Structure of the DOMEleme
             $expected = new DOMElement('foo');
             $actual = new DOMElement('bar');
 
-            $this->assertEqualXMLStructure($expected, $actual);
+            self::assertEqualXMLStructure($expected, $actual);
         }
 
         public function testFailureWithDifferentNodeAttributes()
@@ -713,7 +713,7 @@ Reports an error identified by ``$message`` if the XML Structure of the DOMEleme
             $actual = new DOMDocument;
             $actual->loadXML('<foo/>');
 
-            $this->assertEqualXMLStructure(
+            self::assertEqualXMLStructure(
               $expected->firstChild, $actual->firstChild, true
             );
         }
@@ -726,7 +726,7 @@ Reports an error identified by ``$message`` if the XML Structure of the DOMEleme
             $actual = new DOMDocument;
             $actual->loadXML('<foo><bar/></foo>');
 
-            $this->assertEqualXMLStructure(
+            self::assertEqualXMLStructure(
               $expected->firstChild, $actual->firstChild
             );
         }
@@ -739,7 +739,7 @@ Reports an error identified by ``$message`` if the XML Structure of the DOMEleme
             $actual = new DOMDocument;
             $actual->loadXML('<foo><baz/><baz/><baz/></foo>');
 
-            $this->assertEqualXMLStructure(
+            self::assertEqualXMLStructure(
               $expected->firstChild, $actual->firstChild
             );
         }
@@ -813,17 +813,17 @@ Reports an error identified by ``$message`` if the two variables ``$expected`` a
     {
         public function testFailure()
         {
-            $this->assertEquals(1, 0);
+            self::assertEquals(1, 0);
         }
 
         public function testFailure2()
         {
-            $this->assertEquals('bar', 'baz');
+            self::assertEquals('bar', 'baz');
         }
 
         public function testFailure3()
         {
-            $this->assertEquals("foo\nbar\nbaz\n", "foo\nbah\nbaz\n");
+            self::assertEquals("foo\nbar\nbaz\n", "foo\nbah\nbaz\n");
         }
     }
 
@@ -892,7 +892,7 @@ Reports an error identified by ``$message`` if the uncommented canonical form of
             $actual = new DOMDocument;
             $actual->loadXML('<bar><foo/></bar>');
 
-            $this->assertEquals($expected, $actual);
+            self::assertEquals($expected, $actual);
         }
     }
 
@@ -948,7 +948,7 @@ Reports an error identified by ``$message`` if the two objects ``$expected`` and
             $actual->foo = 'bar';
             $actual->baz = 'bar';
 
-            $this->assertEquals($expected, $actual);
+            self::assertEquals($expected, $actual);
         }
     }
 
@@ -995,7 +995,7 @@ Reports an error identified by ``$message`` if the two arrays ``$expected`` and 
     {
         public function testFailure()
         {
-            $this->assertEquals(['a', 'b', 'c'], ['a', 'c', 'd']);
+            self::assertEquals(['a', 'b', 'c'], ['a', 'c', 'd']);
         }
     }
 
@@ -1050,7 +1050,7 @@ The contents of ``$expected`` and ``$actual`` are canonicalized before they are 
     {
         public function testFailure()
         {
-            $this->assertEqualsCanonicalizing([3, 2, 1], [2, 3, 0, 1]);
+            self::assertEqualsCanonicalizing([3, 2, 1], [2, 3, 0, 1]);
         }
     }
 
@@ -1107,7 +1107,7 @@ Differences in casing are ignored for the comparison of ``$expected`` and ``$act
     {
         public function testFailure()
         {
-            $this->assertEqualsIgnoringCase('foo', 'BAR');
+            self::assertEqualsIgnoringCase('foo', 'BAR');
         }
     }
 
@@ -1157,7 +1157,7 @@ Please read "`What Every Computer Scientist Should Know About Floating-Point Ari
     {
         public function testFailure()
         {
-            $this->assertEqualsWithDelta(1.0, 1.5, 0.1);
+            self::assertEqualsWithDelta(1.0, 1.5, 0.1);
         }
     }
 
@@ -1202,7 +1202,7 @@ Reports an error identified by ``$message`` if ``$condition`` is ``true``.
     {
         public function testFailure()
         {
-            $this->assertFalse(true);
+            self::assertFalse(true);
         }
     }
 
@@ -1247,7 +1247,7 @@ Reports an error identified by ``$message`` if the file specified by ``$expected
     {
         public function testFailure()
         {
-            $this->assertFileEquals('/home/sb/expected', '/home/sb/actual');
+            self::assertFileEquals('/home/sb/expected', '/home/sb/actual');
         }
     }
 
@@ -1298,7 +1298,7 @@ Reports an error identified by ``$message`` if the file specified by ``$filename
     {
         public function testFailure()
         {
-            $this->assertFileExists('/path/to/file');
+            self::assertFileExists('/path/to/file');
         }
     }
 
@@ -1343,7 +1343,7 @@ Reports an error identified by ``$message`` if the file specified by ``$filename
     {
         public function testFailure()
         {
-            $this->assertFileIsReadable('/path/to/file');
+            self::assertFileIsReadable('/path/to/file');
         }
     }
 
@@ -1388,7 +1388,7 @@ Reports an error identified by ``$message`` if the file specified by ``$filename
     {
         public function testFailure()
         {
-            $this->assertFileIsWritable('/path/to/file');
+            self::assertFileIsWritable('/path/to/file');
         }
     }
 
@@ -1431,7 +1431,7 @@ Reports an error identified by ``$message`` if the value of ``$actual`` is not g
     {
         public function testFailure()
         {
-            $this->assertGreaterThan(2, 1);
+            self::assertGreaterThan(2, 1);
         }
     }
 
@@ -1474,7 +1474,7 @@ Reports an error identified by ``$message`` if the value of ``$actual`` is not g
     {
         public function testFailure()
         {
-            $this->assertGreaterThanOrEqual(2, 1);
+            self::assertGreaterThanOrEqual(2, 1);
         }
     }
     ?>
@@ -1520,7 +1520,7 @@ Reports an error identified by ``$message`` if ``$variable`` is not ``INF``.
     {
         public function testFailure()
         {
-            $this->assertInfinite(1);
+            self::assertInfinite(1);
         }
     }
     ?>
@@ -1566,7 +1566,7 @@ Reports an error identified by ``$message`` if ``$actual`` is not an instance of
     {
         public function testFailure()
         {
-            $this->assertInstanceOf(RuntimeException::class, new Exception);
+            self::assertInstanceOf(RuntimeException::class, new Exception);
         }
     }
     ?>
@@ -1610,7 +1610,7 @@ Reports an error identified by ``$message`` if ``$actual`` is not of type ``arra
     {
         public function testFailure()
         {
-            $this->assertIsArray(null);
+            self::assertIsArray(null);
         }
     }
 
@@ -1653,7 +1653,7 @@ Reports an error identified by ``$message`` if ``$actual`` is not of type ``bool
     {
         public function testFailure()
         {
-            $this->assertIsBool(null);
+            self::assertIsBool(null);
         }
     }
 
@@ -1696,7 +1696,7 @@ Reports an error identified by ``$message`` if ``$actual`` is not of type ``call
     {
         public function testFailure()
         {
-            $this->assertIsCallable(null);
+            self::assertIsCallable(null);
         }
     }
 
@@ -1739,7 +1739,7 @@ Reports an error identified by ``$message`` if ``$actual`` is not of type ``floa
     {
         public function testFailure()
         {
-            $this->assertIsFloat(null);
+            self::assertIsFloat(null);
         }
     }
 
@@ -1782,7 +1782,7 @@ Reports an error identified by ``$message`` if ``$actual`` is not of type ``int`
     {
         public function testFailure()
         {
-            $this->assertIsInt(null);
+            self::assertIsInt(null);
         }
     }
 
@@ -1825,7 +1825,7 @@ Reports an error identified by ``$message`` if ``$actual`` is not of type ``iter
     {
         public function testFailure()
         {
-            $this->assertIsIterable(null);
+            self::assertIsIterable(null);
         }
     }
 
@@ -1868,7 +1868,7 @@ Reports an error identified by ``$message`` if ``$actual`` is not of type ``nume
     {
         public function testFailure()
         {
-            $this->assertIsNumeric(null);
+            self::assertIsNumeric(null);
         }
     }
 
@@ -1911,7 +1911,7 @@ Reports an error identified by ``$message`` if ``$actual`` is not of type ``obje
     {
         public function testFailure()
         {
-            $this->assertIsObject(null);
+            self::assertIsObject(null);
         }
     }
 
@@ -1954,7 +1954,7 @@ Reports an error identified by ``$message`` if ``$actual`` is not of type ``reso
     {
         public function testFailure()
         {
-            $this->assertIsResource(null);
+            self::assertIsResource(null);
         }
     }
 
@@ -1997,7 +1997,7 @@ Reports an error identified by ``$message`` if ``$actual`` is not of type ``scal
     {
         public function testFailure()
         {
-            $this->assertIsScalar(null);
+            self::assertIsScalar(null);
         }
     }
 
@@ -2040,7 +2040,7 @@ Reports an error identified by ``$message`` if ``$actual`` is not of type ``stri
     {
         public function testFailure()
         {
-            $this->assertIsString(null);
+            self::assertIsString(null);
         }
     }
 
@@ -2085,7 +2085,7 @@ Reports an error identified by ``$message`` if the file or directory specified b
     {
         public function testFailure()
         {
-            $this->assertIsReadable('/path/to/unreadable');
+            self::assertIsReadable('/path/to/unreadable');
         }
     }
     ?>
@@ -2131,7 +2131,7 @@ Reports an error identified by ``$message`` if the file or directory specified b
     {
         public function testFailure()
         {
-            $this->assertIsWritable('/path/to/unwritable');
+            self::assertIsWritable('/path/to/unwritable');
         }
     }
     ?>
@@ -2176,7 +2176,7 @@ Reports an error identified by ``$message`` if the value of ``$actualFile`` does
     {
         public function testFailure()
         {
-            $this->assertJsonFileEqualsJsonFile(
+            self::assertJsonFileEqualsJsonFile(
               'path/to/fixture/file', 'path/to/actual/file');
         }
     }
@@ -2222,7 +2222,7 @@ Reports an error identified by ``$message`` if the value of ``$actualJson`` does
     {
         public function testFailure()
         {
-            $this->assertJsonStringEqualsJsonFile(
+            self::assertJsonStringEqualsJsonFile(
                 'path/to/fixture/file', json_encode(['Mascot' => 'ux'])
             );
         }
@@ -2269,7 +2269,7 @@ Reports an error identified by ``$message`` if the value of ``$actualJson`` does
     {
         public function testFailure()
         {
-            $this->assertJsonStringEqualsJsonString(
+            self::assertJsonStringEqualsJsonString(
                 json_encode(['Mascot' => 'Tux']),
                 json_encode(['Mascot' => 'ux'])
             );
@@ -2323,7 +2323,7 @@ Reports an error identified by ``$message`` if the value of ``$actual`` is not l
     {
         public function testFailure()
         {
-            $this->assertLessThan(1, 2);
+            self::assertLessThan(1, 2);
         }
     }
     ?>
@@ -2367,7 +2367,7 @@ Reports an error identified by ``$message`` if the value of ``$actual`` is not l
     {
         public function testFailure()
         {
-            $this->assertLessThanOrEqual(1, 2);
+            self::assertLessThanOrEqual(1, 2);
         }
     }
     ?>
@@ -2411,7 +2411,7 @@ Reports an error identified by ``$message`` if ``$variable`` is not ``NAN``.
     {
         public function testFailure()
         {
-            $this->assertNan(1);
+            self::assertNan(1);
         }
     }
     ?>
@@ -2457,7 +2457,7 @@ Reports an error identified by ``$message`` if ``$variable`` is not ``null``.
     {
         public function testFailure()
         {
-            $this->assertNull('foo');
+            self::assertNull('foo');
         }
     }
     ?>
@@ -2503,7 +2503,7 @@ Reports an error identified by ``$message`` if ``$object->attributeName`` does n
     {
         public function testFailure()
         {
-            $this->assertObjectHasAttribute('foo', new stdClass);
+            self::assertObjectHasAttribute('foo', new stdClass);
         }
     }
     ?>
@@ -2549,7 +2549,7 @@ Reports an error identified by ``$message`` if ``$string`` does not match the re
     {
         public function testFailure()
         {
-            $this->assertRegExp('/foo/', 'bar');
+            self::assertRegExp('/foo/', 'bar');
         }
     }
     ?>
@@ -2595,7 +2595,7 @@ Reports an error identified by ``$message`` if the ``$string`` does not match th
     {
         public function testFailure()
         {
-            $this->assertStringMatchesFormat('%i', 'foo');
+            self::assertStringMatchesFormat('%i', 'foo');
         }
     }
     ?>
@@ -2691,7 +2691,7 @@ Reports an error identified by ``$message`` if the ``$string`` does not match th
     {
         public function testFailure()
         {
-            $this->assertStringMatchesFormatFile('/path/to/expected.txt', 'foo');
+            self::assertStringMatchesFormatFile('/path/to/expected.txt', 'foo');
         }
     }
     ?>
@@ -2738,7 +2738,7 @@ Reports an error identified by ``$message`` if the two variables ``$expected`` a
     {
         public function testFailure()
         {
-            $this->assertSame('2204', 2204);
+            self::assertSame('2204', 2204);
         }
     }
     ?>
@@ -2777,7 +2777,7 @@ Reports an error identified by ``$message`` if the two variables ``$expected`` a
     {
         public function testFailure()
         {
-            $this->assertSame(new stdClass, new stdClass);
+            self::assertSame(new stdClass, new stdClass);
         }
     }
     ?>
@@ -2823,7 +2823,7 @@ Reports an error identified by ``$message`` if the ``$string`` does not end with
     {
         public function testFailure()
         {
-            $this->assertStringEndsWith('suffix', 'foo');
+            self::assertStringEndsWith('suffix', 'foo');
         }
     }
     ?>
@@ -2869,7 +2869,7 @@ Reports an error identified by ``$message`` if the file specified by ``$expected
     {
         public function testFailure()
         {
-            $this->assertStringEqualsFile('/home/sb/expected', 'actual');
+            self::assertStringEqualsFile('/home/sb/expected', 'actual');
         }
     }
     ?>
@@ -2921,7 +2921,7 @@ Reports an error identified by ``$message`` if the ``$string`` does not start wi
     {
         public function testFailure()
         {
-            $this->assertStringStartsWith('prefix', 'foo');
+            self::assertStringStartsWith('prefix', 'foo');
         }
     }
     ?>
@@ -2976,7 +2976,7 @@ Reports an error identified by ``$message`` if the ``$value`` does not match the
             $theBiscuit = new Biscuit('Ginger');
             $myBiscuit  = new Biscuit('Ginger');
 
-            $this->assertThat(
+            self::assertThat(
               $theBiscuit,
               $this->logicalNot(
                 $this->equalTo($myBiscuit)
@@ -3085,7 +3085,7 @@ Reports an error identified by ``$message`` if ``$condition`` is ``false``.
     {
         public function testFailure()
         {
-            $this->assertTrue(false);
+            self::assertTrue(false);
         }
     }
     ?>
@@ -3131,7 +3131,7 @@ Reports an error identified by ``$message`` if the XML document in ``$actualFile
     {
         public function testFailure()
         {
-            $this->assertXmlFileEqualsXmlFile(
+            self::assertXmlFileEqualsXmlFile(
               '/home/sb/expected.xml', '/home/sb/actual.xml');
         }
     }
@@ -3186,7 +3186,7 @@ Reports an error identified by ``$message`` if the XML document in ``$actualXml`
     {
         public function testFailure()
         {
-            $this->assertXmlStringEqualsXmlFile(
+            self::assertXmlStringEqualsXmlFile(
               '/home/sb/expected.xml', '<foo><baz/></foo>');
         }
     }
@@ -3241,7 +3241,7 @@ Reports an error identified by ``$message`` if the XML document in ``$actualXml`
     {
         public function testFailure()
         {
-            $this->assertXmlStringEqualsXmlString(
+            self::assertXmlStringEqualsXmlString(
               '<foo><bar/></foo>', '<foo><baz/></foo>');
         }
     }

--- a/src/assertions.rst
+++ b/src/assertions.rst
@@ -18,7 +18,7 @@ PHPUnit's assertions are implemented in ``PHPUnit\Framework\Assert``.
 
 The assertion methods are declared static and can be invoked
 from any context using ``PHPUnit\Framework\Assert::assertTrue()``,
-for instance, or using ``self::assertTrue()`` or ``self::assertTrue()``,
+for instance, or using ``$this->assertTrue()`` or ``self::assertTrue()``,
 for instance, in a class that extends ``PHPUnit\Framework\TestCase``.
 
 In fact, you can even use global function wrappers such as ``assertTrue()`` in
@@ -27,17 +27,17 @@ when you (manually) include the :file:`src/Framework/Assert/Functions.php`
 sourcecode file that comes with PHPUnit.
 
 A common question, especially from developers new to PHPUnit, is whether
-using ``self::assertTrue()`` or ``self::assertTrue()``,
+using ``$this->assertTrue()`` or ``self::assertTrue()``,
 for instance, is "the right way" to invoke an assertion. The short answer
 is: there is no right way. And there is no wrong way, either. It is a
 matter of personal preference.
 
-For most people it just "feels right" to use ``self::assertTrue()``
+For most people it just "feels right" to use ``$this->assertTrue()``
 because the test method is invoked on a test object. The fact that the
 assertion methods are declared static allows for (re)using
 them outside the scope of a test object. Lastly, the global function
 wrappers allow developers to type less characters (``assertTrue()`` instead
-of ``self::assertTrue()`` or ``self::assertTrue()``).
+of ``$this->assertTrue()`` or ``self::assertTrue()``).
 
 .. _appendixes.assertions.assertArrayHasKey:
 
@@ -61,7 +61,7 @@ Reports an error identified by ``$message`` if ``$array`` does not have the ``$k
     {
         public function testFailure()
         {
-            self::assertArrayHasKey('foo', ['bar' => 'baz']);
+            $this->assertArrayHasKey('foo', ['bar' => 'baz']);
         }
     }
 
@@ -106,7 +106,7 @@ Reports an error identified by ``$message`` if ``$className::attributeName`` doe
     {
         public function testFailure()
         {
-            self::assertClassHasAttribute('foo', stdClass::class);
+            $this->assertClassHasAttribute('foo', stdClass::class);
         }
     }
 
@@ -151,7 +151,7 @@ Reports an error identified by ``$message`` if ``$array`` does not contains the 
     {
         public function testFailure()
         {
-            self::assertArraySubset(['config' => ['key-a', 'key-b']], ['config' => ['key-a']]);
+            $this->assertArraySubset(['config' => ['key-a', 'key-b']], ['config' => ['key-a']]);
         }
     }
 
@@ -201,7 +201,7 @@ Reports an error identified by ``$message`` if ``$className::attributeName`` doe
     {
         public function testFailure()
         {
-            self::assertClassHasStaticAttribute('foo', stdClass::class);
+            $this->assertClassHasStaticAttribute('foo', stdClass::class);
         }
     }
 
@@ -246,7 +246,7 @@ Reports an error identified by ``$message`` if ``$needle`` is not an element of 
     {
         public function testFailure()
         {
-            self::assertContains(4, [1, 2, 3]);
+            $this->assertContains(4, [1, 2, 3]);
         }
     }
 
@@ -289,7 +289,7 @@ Reports an error identified by ``$message`` if ``$needle`` is not a substring of
     {
         public function testFailure()
         {
-            self::assertStringContainsString('foo', 'bar');
+            $this->assertStringContainsString('foo', 'bar');
         }
     }
 
@@ -334,7 +334,7 @@ Differences in casing are ignored when ``$needle`` is searched for in ``$haystac
     {
         public function testFailure()
         {
-            self::assertStringContainsStringIgnoringCase('foo', 'bar');
+            $this->assertStringContainsStringIgnoringCase('foo', 'bar');
         }
     }
 
@@ -381,7 +381,7 @@ Reports an error identified by ``$message`` if ``$haystack`` does not contain on
     {
         public function testFailure()
         {
-            self::assertContainsOnly('string', ['1', '2', 3]);
+            $this->assertContainsOnly('string', ['1', '2', 3]);
         }
     }
 
@@ -428,7 +428,7 @@ Reports an error identified by ``$message`` if ``$haystack`` does not contain on
     {
         public function testFailure()
         {
-            self::assertContainsOnlyInstancesOf(
+            $this->assertContainsOnlyInstancesOf(
                 Foo::class,
                 [new Foo, new Bar, new Foo]
             );
@@ -476,7 +476,7 @@ Reports an error identified by ``$message`` if the number of elements in ``$hays
     {
         public function testFailure()
         {
-            self::assertCount(0, ['foo']);
+            $this->assertCount(0, ['foo']);
         }
     }
 
@@ -521,7 +521,7 @@ Reports an error identified by ``$message`` if the directory specified by ``$dir
     {
         public function testFailure()
         {
-            self::assertDirectoryExists('/path/to/directory');
+            $this->assertDirectoryExists('/path/to/directory');
         }
     }
 
@@ -566,7 +566,7 @@ Reports an error identified by ``$message`` if the directory specified by ``$dir
     {
         public function testFailure()
         {
-            self::assertDirectoryIsReadable('/path/to/directory');
+            $this->assertDirectoryIsReadable('/path/to/directory');
         }
     }
 
@@ -611,7 +611,7 @@ Reports an error identified by ``$message`` if the directory specified by ``$dir
     {
         public function testFailure()
         {
-            self::assertDirectoryIsWritable('/path/to/directory');
+            $this->assertDirectoryIsWritable('/path/to/directory');
         }
     }
 
@@ -656,7 +656,7 @@ Reports an error identified by ``$message`` if ``$actual`` is not empty.
     {
         public function testFailure()
         {
-            self::assertEmpty(['foo']);
+            $this->assertEmpty(['foo']);
         }
     }
 
@@ -702,7 +702,7 @@ Reports an error identified by ``$message`` if the XML Structure of the DOMEleme
             $expected = new DOMElement('foo');
             $actual = new DOMElement('bar');
 
-            self::assertEqualXMLStructure($expected, $actual);
+            $this->assertEqualXMLStructure($expected, $actual);
         }
 
         public function testFailureWithDifferentNodeAttributes()
@@ -713,7 +713,7 @@ Reports an error identified by ``$message`` if the XML Structure of the DOMEleme
             $actual = new DOMDocument;
             $actual->loadXML('<foo/>');
 
-            self::assertEqualXMLStructure(
+            $this->assertEqualXMLStructure(
               $expected->firstChild, $actual->firstChild, true
             );
         }
@@ -726,7 +726,7 @@ Reports an error identified by ``$message`` if the XML Structure of the DOMEleme
             $actual = new DOMDocument;
             $actual->loadXML('<foo><bar/></foo>');
 
-            self::assertEqualXMLStructure(
+            $this->assertEqualXMLStructure(
               $expected->firstChild, $actual->firstChild
             );
         }
@@ -739,7 +739,7 @@ Reports an error identified by ``$message`` if the XML Structure of the DOMEleme
             $actual = new DOMDocument;
             $actual->loadXML('<foo><baz/><baz/><baz/></foo>');
 
-            self::assertEqualXMLStructure(
+            $this->assertEqualXMLStructure(
               $expected->firstChild, $actual->firstChild
             );
         }
@@ -813,17 +813,17 @@ Reports an error identified by ``$message`` if the two variables ``$expected`` a
     {
         public function testFailure()
         {
-            self::assertEquals(1, 0);
+            $this->assertEquals(1, 0);
         }
 
         public function testFailure2()
         {
-            self::assertEquals('bar', 'baz');
+            $this->assertEquals('bar', 'baz');
         }
 
         public function testFailure3()
         {
-            self::assertEquals("foo\nbar\nbaz\n", "foo\nbah\nbaz\n");
+            $this->assertEquals("foo\nbar\nbaz\n", "foo\nbah\nbaz\n");
         }
     }
 
@@ -892,7 +892,7 @@ Reports an error identified by ``$message`` if the uncommented canonical form of
             $actual = new DOMDocument;
             $actual->loadXML('<bar><foo/></bar>');
 
-            self::assertEquals($expected, $actual);
+            $this->assertEquals($expected, $actual);
         }
     }
 
@@ -948,7 +948,7 @@ Reports an error identified by ``$message`` if the two objects ``$expected`` and
             $actual->foo = 'bar';
             $actual->baz = 'bar';
 
-            self::assertEquals($expected, $actual);
+            $this->assertEquals($expected, $actual);
         }
     }
 
@@ -995,7 +995,7 @@ Reports an error identified by ``$message`` if the two arrays ``$expected`` and 
     {
         public function testFailure()
         {
-            self::assertEquals(['a', 'b', 'c'], ['a', 'c', 'd']);
+            $this->assertEquals(['a', 'b', 'c'], ['a', 'c', 'd']);
         }
     }
 
@@ -1050,7 +1050,7 @@ The contents of ``$expected`` and ``$actual`` are canonicalized before they are 
     {
         public function testFailure()
         {
-            self::assertEqualsCanonicalizing([3, 2, 1], [2, 3, 0, 1]);
+            $this->assertEqualsCanonicalizing([3, 2, 1], [2, 3, 0, 1]);
         }
     }
 
@@ -1107,7 +1107,7 @@ Differences in casing are ignored for the comparison of ``$expected`` and ``$act
     {
         public function testFailure()
         {
-            self::assertEqualsIgnoringCase('foo', 'BAR');
+            $this->assertEqualsIgnoringCase('foo', 'BAR');
         }
     }
 
@@ -1157,7 +1157,7 @@ Please read "`What Every Computer Scientist Should Know About Floating-Point Ari
     {
         public function testFailure()
         {
-            self::assertEqualsWithDelta(1.0, 1.5, 0.1);
+            $this->assertEqualsWithDelta(1.0, 1.5, 0.1);
         }
     }
 
@@ -1202,7 +1202,7 @@ Reports an error identified by ``$message`` if ``$condition`` is ``true``.
     {
         public function testFailure()
         {
-            self::assertFalse(true);
+            $this->assertFalse(true);
         }
     }
 
@@ -1247,7 +1247,7 @@ Reports an error identified by ``$message`` if the file specified by ``$expected
     {
         public function testFailure()
         {
-            self::assertFileEquals('/home/sb/expected', '/home/sb/actual');
+            $this->assertFileEquals('/home/sb/expected', '/home/sb/actual');
         }
     }
 
@@ -1298,7 +1298,7 @@ Reports an error identified by ``$message`` if the file specified by ``$filename
     {
         public function testFailure()
         {
-            self::assertFileExists('/path/to/file');
+            $this->assertFileExists('/path/to/file');
         }
     }
 
@@ -1343,7 +1343,7 @@ Reports an error identified by ``$message`` if the file specified by ``$filename
     {
         public function testFailure()
         {
-            self::assertFileIsReadable('/path/to/file');
+            $this->assertFileIsReadable('/path/to/file');
         }
     }
 
@@ -1388,7 +1388,7 @@ Reports an error identified by ``$message`` if the file specified by ``$filename
     {
         public function testFailure()
         {
-            self::assertFileIsWritable('/path/to/file');
+            $this->assertFileIsWritable('/path/to/file');
         }
     }
 
@@ -1431,7 +1431,7 @@ Reports an error identified by ``$message`` if the value of ``$actual`` is not g
     {
         public function testFailure()
         {
-            self::assertGreaterThan(2, 1);
+            $this->assertGreaterThan(2, 1);
         }
     }
 
@@ -1474,7 +1474,7 @@ Reports an error identified by ``$message`` if the value of ``$actual`` is not g
     {
         public function testFailure()
         {
-            self::assertGreaterThanOrEqual(2, 1);
+            $this->assertGreaterThanOrEqual(2, 1);
         }
     }
     ?>
@@ -1520,7 +1520,7 @@ Reports an error identified by ``$message`` if ``$variable`` is not ``INF``.
     {
         public function testFailure()
         {
-            self::assertInfinite(1);
+            $this->assertInfinite(1);
         }
     }
     ?>
@@ -1566,7 +1566,7 @@ Reports an error identified by ``$message`` if ``$actual`` is not an instance of
     {
         public function testFailure()
         {
-            self::assertInstanceOf(RuntimeException::class, new Exception);
+            $this->assertInstanceOf(RuntimeException::class, new Exception);
         }
     }
     ?>
@@ -1610,7 +1610,7 @@ Reports an error identified by ``$message`` if ``$actual`` is not of type ``arra
     {
         public function testFailure()
         {
-            self::assertIsArray(null);
+            $this->assertIsArray(null);
         }
     }
 
@@ -1653,7 +1653,7 @@ Reports an error identified by ``$message`` if ``$actual`` is not of type ``bool
     {
         public function testFailure()
         {
-            self::assertIsBool(null);
+            $this->assertIsBool(null);
         }
     }
 
@@ -1696,7 +1696,7 @@ Reports an error identified by ``$message`` if ``$actual`` is not of type ``call
     {
         public function testFailure()
         {
-            self::assertIsCallable(null);
+            $this->assertIsCallable(null);
         }
     }
 
@@ -1739,7 +1739,7 @@ Reports an error identified by ``$message`` if ``$actual`` is not of type ``floa
     {
         public function testFailure()
         {
-            self::assertIsFloat(null);
+            $this->assertIsFloat(null);
         }
     }
 
@@ -1782,7 +1782,7 @@ Reports an error identified by ``$message`` if ``$actual`` is not of type ``int`
     {
         public function testFailure()
         {
-            self::assertIsInt(null);
+            $this->assertIsInt(null);
         }
     }
 
@@ -1825,7 +1825,7 @@ Reports an error identified by ``$message`` if ``$actual`` is not of type ``iter
     {
         public function testFailure()
         {
-            self::assertIsIterable(null);
+            $this->assertIsIterable(null);
         }
     }
 
@@ -1868,7 +1868,7 @@ Reports an error identified by ``$message`` if ``$actual`` is not of type ``nume
     {
         public function testFailure()
         {
-            self::assertIsNumeric(null);
+            $this->assertIsNumeric(null);
         }
     }
 
@@ -1911,7 +1911,7 @@ Reports an error identified by ``$message`` if ``$actual`` is not of type ``obje
     {
         public function testFailure()
         {
-            self::assertIsObject(null);
+            $this->assertIsObject(null);
         }
     }
 
@@ -1954,7 +1954,7 @@ Reports an error identified by ``$message`` if ``$actual`` is not of type ``reso
     {
         public function testFailure()
         {
-            self::assertIsResource(null);
+            $this->assertIsResource(null);
         }
     }
 
@@ -1997,7 +1997,7 @@ Reports an error identified by ``$message`` if ``$actual`` is not of type ``scal
     {
         public function testFailure()
         {
-            self::assertIsScalar(null);
+            $this->assertIsScalar(null);
         }
     }
 
@@ -2040,7 +2040,7 @@ Reports an error identified by ``$message`` if ``$actual`` is not of type ``stri
     {
         public function testFailure()
         {
-            self::assertIsString(null);
+            $this->assertIsString(null);
         }
     }
 
@@ -2085,7 +2085,7 @@ Reports an error identified by ``$message`` if the file or directory specified b
     {
         public function testFailure()
         {
-            self::assertIsReadable('/path/to/unreadable');
+            $this->assertIsReadable('/path/to/unreadable');
         }
     }
     ?>
@@ -2131,7 +2131,7 @@ Reports an error identified by ``$message`` if the file or directory specified b
     {
         public function testFailure()
         {
-            self::assertIsWritable('/path/to/unwritable');
+            $this->assertIsWritable('/path/to/unwritable');
         }
     }
     ?>
@@ -2176,7 +2176,7 @@ Reports an error identified by ``$message`` if the value of ``$actualFile`` does
     {
         public function testFailure()
         {
-            self::assertJsonFileEqualsJsonFile(
+            $this->assertJsonFileEqualsJsonFile(
               'path/to/fixture/file', 'path/to/actual/file');
         }
     }
@@ -2222,7 +2222,7 @@ Reports an error identified by ``$message`` if the value of ``$actualJson`` does
     {
         public function testFailure()
         {
-            self::assertJsonStringEqualsJsonFile(
+            $this->assertJsonStringEqualsJsonFile(
                 'path/to/fixture/file', json_encode(['Mascot' => 'ux'])
             );
         }
@@ -2269,7 +2269,7 @@ Reports an error identified by ``$message`` if the value of ``$actualJson`` does
     {
         public function testFailure()
         {
-            self::assertJsonStringEqualsJsonString(
+            $this->assertJsonStringEqualsJsonString(
                 json_encode(['Mascot' => 'Tux']),
                 json_encode(['Mascot' => 'ux'])
             );
@@ -2323,7 +2323,7 @@ Reports an error identified by ``$message`` if the value of ``$actual`` is not l
     {
         public function testFailure()
         {
-            self::assertLessThan(1, 2);
+            $this->assertLessThan(1, 2);
         }
     }
     ?>
@@ -2367,7 +2367,7 @@ Reports an error identified by ``$message`` if the value of ``$actual`` is not l
     {
         public function testFailure()
         {
-            self::assertLessThanOrEqual(1, 2);
+            $this->assertLessThanOrEqual(1, 2);
         }
     }
     ?>
@@ -2411,7 +2411,7 @@ Reports an error identified by ``$message`` if ``$variable`` is not ``NAN``.
     {
         public function testFailure()
         {
-            self::assertNan(1);
+            $this->assertNan(1);
         }
     }
     ?>
@@ -2457,7 +2457,7 @@ Reports an error identified by ``$message`` if ``$variable`` is not ``null``.
     {
         public function testFailure()
         {
-            self::assertNull('foo');
+            $this->assertNull('foo');
         }
     }
     ?>
@@ -2503,7 +2503,7 @@ Reports an error identified by ``$message`` if ``$object->attributeName`` does n
     {
         public function testFailure()
         {
-            self::assertObjectHasAttribute('foo', new stdClass);
+            $this->assertObjectHasAttribute('foo', new stdClass);
         }
     }
     ?>
@@ -2549,7 +2549,7 @@ Reports an error identified by ``$message`` if ``$string`` does not match the re
     {
         public function testFailure()
         {
-            self::assertRegExp('/foo/', 'bar');
+            $this->assertRegExp('/foo/', 'bar');
         }
     }
     ?>
@@ -2595,7 +2595,7 @@ Reports an error identified by ``$message`` if the ``$string`` does not match th
     {
         public function testFailure()
         {
-            self::assertStringMatchesFormat('%i', 'foo');
+            $this->assertStringMatchesFormat('%i', 'foo');
         }
     }
     ?>
@@ -2691,7 +2691,7 @@ Reports an error identified by ``$message`` if the ``$string`` does not match th
     {
         public function testFailure()
         {
-            self::assertStringMatchesFormatFile('/path/to/expected.txt', 'foo');
+            $this->assertStringMatchesFormatFile('/path/to/expected.txt', 'foo');
         }
     }
     ?>
@@ -2738,7 +2738,7 @@ Reports an error identified by ``$message`` if the two variables ``$expected`` a
     {
         public function testFailure()
         {
-            self::assertSame('2204', 2204);
+            $this->assertSame('2204', 2204);
         }
     }
     ?>
@@ -2777,7 +2777,7 @@ Reports an error identified by ``$message`` if the two variables ``$expected`` a
     {
         public function testFailure()
         {
-            self::assertSame(new stdClass, new stdClass);
+            $this->assertSame(new stdClass, new stdClass);
         }
     }
     ?>
@@ -2823,7 +2823,7 @@ Reports an error identified by ``$message`` if the ``$string`` does not end with
     {
         public function testFailure()
         {
-            self::assertStringEndsWith('suffix', 'foo');
+            $this->assertStringEndsWith('suffix', 'foo');
         }
     }
     ?>
@@ -2869,7 +2869,7 @@ Reports an error identified by ``$message`` if the file specified by ``$expected
     {
         public function testFailure()
         {
-            self::assertStringEqualsFile('/home/sb/expected', 'actual');
+            $this->assertStringEqualsFile('/home/sb/expected', 'actual');
         }
     }
     ?>
@@ -2921,7 +2921,7 @@ Reports an error identified by ``$message`` if the ``$string`` does not start wi
     {
         public function testFailure()
         {
-            self::assertStringStartsWith('prefix', 'foo');
+            $this->assertStringStartsWith('prefix', 'foo');
         }
     }
     ?>
@@ -2976,7 +2976,7 @@ Reports an error identified by ``$message`` if the ``$value`` does not match the
             $theBiscuit = new Biscuit('Ginger');
             $myBiscuit  = new Biscuit('Ginger');
 
-            self::assertThat(
+            $this->assertThat(
               $theBiscuit,
               $this->logicalNot(
                 $this->equalTo($myBiscuit)
@@ -3085,7 +3085,7 @@ Reports an error identified by ``$message`` if ``$condition`` is ``false``.
     {
         public function testFailure()
         {
-            self::assertTrue(false);
+            $this->assertTrue(false);
         }
     }
     ?>
@@ -3131,7 +3131,7 @@ Reports an error identified by ``$message`` if the XML document in ``$actualFile
     {
         public function testFailure()
         {
-            self::assertXmlFileEqualsXmlFile(
+            $this->assertXmlFileEqualsXmlFile(
               '/home/sb/expected.xml', '/home/sb/actual.xml');
         }
     }
@@ -3186,7 +3186,7 @@ Reports an error identified by ``$message`` if the XML document in ``$actualXml`
     {
         public function testFailure()
         {
-            self::assertXmlStringEqualsXmlFile(
+            $this->assertXmlStringEqualsXmlFile(
               '/home/sb/expected.xml', '<foo><baz/></foo>');
         }
     }
@@ -3241,7 +3241,7 @@ Reports an error identified by ``$message`` if the XML document in ``$actualXml`
     {
         public function testFailure()
         {
-            self::assertXmlStringEqualsXmlString(
+            $this->assertXmlStringEqualsXmlString(
               '<foo><bar/></foo>', '<foo><baz/></foo>');
         }
     }

--- a/src/code-coverage-analysis.rst
+++ b/src/code-coverage-analysis.rst
@@ -232,7 +232,7 @@ shows an example.
 
         public function testAmountInitiallyIsEmpty()
         {
-            $this->assertEquals(new Money(), $this->subject->getAmount);
+            self::assertEquals(new Money(), $this->subject->getAmount);
         }
     }
     ?>
@@ -258,7 +258,7 @@ shows an example.
          */
         public function testBalanceIsInitiallyZero()
         {
-            $this->assertSame(0, $this->ba->getBalance());
+            self::assertSame(0, $this->ba->getBalance());
         }
 
         /**
@@ -271,7 +271,7 @@ shows an example.
             }
 
             catch (BankAccountException $e) {
-                $this->assertSame(0, $this->ba->getBalance());
+                self::assertSame(0, $this->ba->getBalance());
 
                 return;
             }
@@ -289,7 +289,7 @@ shows an example.
             }
 
             catch (BankAccountException $e) {
-                $this->assertSame(0, $this->ba->getBalance());
+                self::assertSame(0, $this->ba->getBalance());
 
                 return;
             }
@@ -304,11 +304,11 @@ shows an example.
          */
         public function testDepositWithdrawMoney()
         {
-            $this->assertSame(0, $this->ba->getBalance());
+            self::assertSame(0, $this->ba->getBalance());
             $this->ba->depositMoney(1);
-            $this->assertSame(1, $this->ba->getBalance());
+            self::assertSame(1, $this->ba->getBalance());
             $this->ba->withdrawMoney(1);
-            $this->assertSame(0, $this->ba->getBalance());
+            self::assertSame(0, $this->ba->getBalance());
         }
     }
     ?>
@@ -344,7 +344,7 @@ generate code coverage with unit tests.
             $expectedTable = $this->createFlatXmlDataSet("expectedBook.xml")
                                   ->getTable("guestbook");
 
-            $this->assertTablesEqual($expectedTable, $queryTable);
+            self::assertTablesEqual($expectedTable, $queryTable);
         }
     }
     ?>

--- a/src/fixtures.rst
+++ b/src/fixtures.rst
@@ -61,21 +61,21 @@ assertion method.
 
         public function testEmpty()
         {
-            $this->assertTrue(empty($this->stack));
+            self::assertTrue(empty($this->stack));
         }
 
         public function testPush()
         {
             array_push($this->stack, 'foo');
-            $this->assertSame('foo', $this->stack[count($this->stack)-1]);
-            $this->assertFalse(empty($this->stack));
+            self::assertSame('foo', $this->stack[count($this->stack)-1]);
+            self::assertFalse(empty($this->stack));
         }
 
         public function testPop()
         {
             array_push($this->stack, 'foo');
-            $this->assertSame('foo', array_pop($this->stack));
-            $this->assertTrue(empty($this->stack));
+            self::assertSame('foo', array_pop($this->stack));
+            self::assertTrue(empty($this->stack));
         }
     }
 
@@ -118,13 +118,13 @@ case class.
         public function testOne()
         {
             fwrite(STDOUT, __METHOD__ . "\n");
-            $this->assertTrue(true);
+            self::assertTrue(true);
         }
 
         public function testTwo()
         {
             fwrite(STDOUT, __METHOD__ . "\n");
-            $this->assertTrue(false);
+            self::assertTrue(false);
         }
 
         protected function assertPostConditions(): void

--- a/src/incomplete-and-skipped-tests.rst
+++ b/src/incomplete-and-skipped-tests.rst
@@ -58,7 +58,7 @@ exception) in the test method, we mark the test as being incomplete.
         public function testSomething()
         {
             // Optional: Test anything here, if you want.
-            $this->assertTrue(true, 'This should already work.');
+            self::assertTrue(true, 'This should already work.');
 
             // Stop here and mark this test as incomplete.
             $this->markTestIncomplete(

--- a/src/test-doubles.rst
+++ b/src/test-doubles.rst
@@ -113,7 +113,7 @@ the example. This leads to more readable and "fluent" code.
 
             // Calling $stub->doSomething() will now return
             // 'foo'.
-            $this->assertSame('foo', $stub->doSomething());
+            self::assertSame('foo', $stub->doSomething());
         }
     }
 
@@ -177,7 +177,7 @@ the same best practice defaults used by ``createStub()``.
 
             // Calling $stub->doSomething() will now return
             // 'foo'.
-            $this->assertSame('foo', $stub->doSomething());
+            self::assertSame('foo', $stub->doSomething());
         }
     }
 
@@ -211,10 +211,10 @@ can achieve this using ``returnArgument()`` instead of
                  ->will($this->returnArgument(0));
 
             // $stub->doSomething('foo') returns 'foo'
-            $this->assertSame('foo', $stub->doSomething('foo'));
+            self::assertSame('foo', $stub->doSomething('foo'));
 
             // $stub->doSomething('bar') returns 'bar'
-            $this->assertSame('bar', $stub->doSomething('bar'));
+            self::assertSame('bar', $stub->doSomething('bar'));
         }
     }
 
@@ -242,7 +242,7 @@ can use ``returnSelf()`` to achieve this.
                  ->will($this->returnSelf());
 
             // $stub->doSomething() returns $stub
-            $this->assertSame($stub, $stub->doSomething());
+            self::assertSame($stub, $stub->doSomething());
         }
     }
 
@@ -279,8 +279,8 @@ an example.
 
             // $stub->doSomething() returns different values depending on
             // the provided arguments.
-            $this->assertSame('d', $stub->doSomething('a', 'b', 'c'));
-            $this->assertSame('h', $stub->doSomething('e', 'f', 'g'));
+            self::assertSame('d', $stub->doSomething('a', 'b', 'c'));
+            self::assertSame('h', $stub->doSomething('e', 'f', 'g'));
         }
     }
 
@@ -310,7 +310,7 @@ result of a callback function or method. See
                  ->will($this->returnCallback('str_rot13'));
 
             // $stub->doSomething($argument) returns str_rot13($argument)
-            $this->assertSame('fbzrguvat', $stub->doSomething('something'));
+            self::assertSame('fbzrguvat', $stub->doSomething('something'));
         }
     }
 
@@ -339,9 +339,9 @@ an example.
                  ->will($this->onConsecutiveCalls(2, 3, 5, 7));
 
             // $stub->doSomething() returns a different value each time
-            $this->assertSame(2, $stub->doSomething());
-            $this->assertSame(3, $stub->doSomething());
-            $this->assertSame(5, $stub->doSomething());
+            self::assertSame(2, $stub->doSomething());
+            self::assertSame(3, $stub->doSomething());
+            self::assertSame(5, $stub->doSomething());
         }
     }
 
@@ -848,7 +848,7 @@ are mocked. This allows for testing the concrete methods of a trait.
                  ->method('abstractMethod')
                  ->will($this->returnValue(true));
 
-            $this->assertTrue($mock->concreteMethod());
+            self::assertTrue($mock->concreteMethod());
         }
     }
 
@@ -884,7 +884,7 @@ abstract class.
                  ->method('abstractMethod')
                  ->will($this->returnValue(true));
 
-            $this->assertTrue($stub->concreteMethod());
+            self::assertTrue($stub->concreteMethod());
         }
     }
 
@@ -956,7 +956,7 @@ example, the web service described in :file:`GoogleSearch.wsdl`.
              * $googleSearch->doGoogleSearch() will now return a stubbed result and
              * the web service's doGoogleSearch() method will not be invoked.
              */
-            $this->assertEquals(
+            self::assertEquals(
               $result,
               $googleSearch->doGoogleSearch(
                 '00000000000000000000000000000000',

--- a/src/textui.rst
+++ b/src/textui.rst
@@ -295,7 +295,7 @@ the following code:
                  */
                 public function testMethod($data)
                 {
-                    $this->assertTrue($data);
+                    self::assertTrue($data);
                 }
 
                 public function provider()

--- a/src/writing-tests-for-phpunit.rst
+++ b/src/writing-tests-for-phpunit.rst
@@ -41,14 +41,14 @@ with PHPUnit:
         public function testPushAndPop()
         {
             $stack = [];
-            $this->assertSame(0, count($stack));
+            self::assertSame(0, count($stack));
 
             array_push($stack, 'foo');
-            $this->assertSame('foo', $stack[count($stack)-1]);
-            $this->assertSame(1, count($stack));
+            self::assertSame('foo', $stack[count($stack)-1]);
+            self::assertSame(1, count($stack));
 
-            $this->assertSame('foo', array_pop($stack));
-            $this->assertSame(0, count($stack));
+            self::assertSame('foo', array_pop($stack));
+            self::assertSame(0, count($stack));
         }
     }
 
@@ -104,7 +104,7 @@ dependencies between test methods.
         public function testEmpty()
         {
             $stack = [];
-            $this->assertEmpty($stack);
+            self::assertEmpty($stack);
 
             return $stack;
         }
@@ -115,8 +115,8 @@ dependencies between test methods.
         public function testPush(array $stack)
         {
             array_push($stack, 'foo');
-            $this->assertSame('foo', $stack[count($stack)-1]);
-            $this->assertNotEmpty($stack);
+            self::assertSame('foo', $stack[count($stack)-1]);
+            self::assertNotEmpty($stack);
 
             return $stack;
         }
@@ -126,8 +126,8 @@ dependencies between test methods.
          */
         public function testPop(array $stack)
         {
-            $this->assertSame('foo', array_pop($stack));
-            $this->assertEmpty($stack);
+            self::assertSame('foo', array_pop($stack));
+            self::assertEmpty($stack);
         }
     }
 
@@ -164,7 +164,7 @@ exploiting the dependencies between tests as shown in
     {
         public function testOne()
         {
-            $this->assertTrue(false);
+            self::assertTrue(false);
         }
 
         /**
@@ -220,13 +220,13 @@ See :numref:`writing-tests-for-phpunit.examples.MultipleDependencies.php`
     {
         public function testProducerFirst()
         {
-            $this->assertTrue(true);
+            self::assertTrue(true);
             return 'first';
         }
 
         public function testProducerSecond()
         {
-            $this->assertTrue(true);
+            self::assertTrue(true);
             return 'second';
         }
 
@@ -236,8 +236,8 @@ See :numref:`writing-tests-for-phpunit.examples.MultipleDependencies.php`
          */
         public function testConsumer($a, $b)
         {
-            $this->assertSame('first', $a);
-            $this->assertSame('second', $b);
+            self::assertSame('first', $a);
+            self::assertSame('second', $b);
         }
     }
 
@@ -283,7 +283,7 @@ of the array as its arguments.
          */
         public function testAdd($a, $b, $expected)
         {
-            $this->assertSame($expected, $a + $b);
+            self::assertSame($expected, $a + $b);
         }
 
         public function additionProvider()
@@ -333,7 +333,7 @@ Output will be more verbose as it'll contain that name of a dataset that breaks 
          */
         public function testAdd($a, $b, $expected)
         {
-            $this->assertSame($expected, $a + $b);
+            self::assertSame($expected, $a + $b);
         }
 
         public function additionProvider()
@@ -382,7 +382,7 @@ Output will be more verbose as it'll contain that name of a dataset that breaks 
          */
         public function testAdd($a, $b, $expected)
         {
-            $this->assertSame($expected, $a + $b);
+            self::assertSame($expected, $a + $b);
         }
 
         public function additionProvider()
@@ -485,13 +485,13 @@ See :numref:`writing-tests-for-phpunit.data-providers.examples.DependencyAndData
 
         public function testProducerFirst()
         {
-            $this->assertTrue(true);
+            self::assertTrue(true);
             return 'first';
         }
 
         public function testProducerSecond()
         {
-            $this->assertTrue(true);
+            self::assertTrue(true);
             return 'second';
         }
 
@@ -502,7 +502,7 @@ See :numref:`writing-tests-for-phpunit.data-providers.examples.DependencyAndData
          */
         public function testConsumer()
         {
-            $this->assertSame(
+            self::assertSame(
                 ['provider1', 'first', 'second'],
                 func_get_args()
             );
@@ -551,7 +551,7 @@ See :numref:`writing-tests-for-phpunit.data-providers.examples.DependencyAndData
          */
         public function testAdd($a, $b, $expected)
         {
-            $this->assertSame($expected, $a + $b);
+            self::assertSame($expected, $a + $b);
         }
 
         public function additionWithNonNegativeNumbersProvider()
@@ -758,7 +758,7 @@ that would lead to an exception raised by PHPUnit's error handler.
         {
             $writer = new FileWriter;
 
-            $this->assertFalse(@$writer->write('/is-not-writeable/file', 'stuff'));
+            self::assertFalse(@$writer->write('/is-not-writeable/file', 'stuff'));
         }
     }
 
@@ -894,7 +894,7 @@ context as possible that can help to identify the problem.
     {
         public function testEquality()
         {
-            $this->assertSame(
+            self::assertSame(
                 [1, 2,  3, 4, 5, 6],
                 [1, 2, 33, 4, 5, 6]
             );
@@ -949,7 +949,7 @@ and provide a few lines of context around every difference.
     {
         public function testEquality()
         {
-            $this->assertSame(
+            self::assertSame(
                 [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2,  3, 4, 5, 6],
                 [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 33, 4, 5, 6]
             );
@@ -1010,7 +1010,7 @@ functions on arrays or objects.
     {
         public function testEquality()
         {
-            $this->assertEquals(
+            self::assertEquals(
                 [1, 2, 3, 4, 5, 6],
                 ['1', 2, 33, 4, 5, 6]
             );


### PR DESCRIPTION
All the assertions methods are static and therefore should be called statically instead of dynamically.
PHP Allows it but performance wise it will be slower as the call is translated on `__call` to call it statically.