### PR TITLE
Fixed no explanation of how to run a test suite.

### DIFF
--- a/src/organizing-tests.rst
+++ b/src/organizing-tests.rst
@@ -120,6 +120,19 @@ directory is recursively traversed.
       </testsuites>
     </phpunit>
 
+To run the test suite, use the the ``--testsuite`` option:
+
+.. parsed-literal::
+
+    $ phpunit --bootstrap src/autoload.php --testsuite money
+    PHPUnit |version|.0 by Sebastian Bergmann and contributors.
+
+    ..
+
+    Time: 167 ms, Memory: 3.00Mb
+
+    OK (2 test, 2 assertions)
+
 If :file:`phpunit.xml` or
 :file:`phpunit.xml.dist` (in that order) exist in the
 current working directory and ``--configuration`` is


### PR DESCRIPTION
The section on defining test suites doesn't say how you run them. Added example command and output, to match the examples further up the page.