### PR TITLE
Typo "regresssion"

### DIFF
--- a/src/annotations.rst
+++ b/src/annotations.rst
@@ -457,7 +457,7 @@ A test can be tagged as belonging to one or more groups using the
         }
 
         /**
-         * @group regresssion
+         * @group regression
          * @group bug2204
          */
         public function testSomethingElse()


### PR DESCRIPTION
Hi.
I just found the small typo in docs.
`regresssion` => `regression`