### PR TITLE
Remove call by class name from CLI

### DIFF
--- a/src/textui.rst
+++ b/src/textui.rst
@@ -78,7 +78,7 @@ the following code:
     $ phpunit --help
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
 
-    Usage: phpunit [options] UnitTest [UnitTest.php]
+    Usage: phpunit [options] UnitTest.php
            phpunit [options] <directory>
 
     Code Coverage Options:

--- a/src/textui.rst
+++ b/src/textui.rst
@@ -555,7 +555,7 @@ Let us take a look at the agile documentation generated for a
 
 .. parsed-literal::
 
-    $ phpunit --testdox BankAccountTest
+    $ phpunit --testdox BankAccountTest.php
     PHPUnit |version|.0 by Sebastian Bergmann and contributors.
 
     BankAccount


### PR DESCRIPTION
This is related to the changes made with https://github.com/sebastianbergmann/phpunit/issues/4012