### PR TITLE
PHPUnit 9.0: Remove `assertArraySubset()`

### DIFF
--- a/src/assertions.rst
+++ b/src/assertions.rst
@@ -129,56 +129,6 @@ Reports an error identified by ``$message`` if ``$className::attributeName`` doe
     FAILURES!
     Tests: 1, Assertions: 1, Failures: 1.
 
-.. _appendixes.assertions.assertArraySubset:
-
-assertArraySubset()
-###################
-
-``assertArraySubset(array $subset, array $array[, bool $strict = false, string $message = ''])``
-
-Reports an error identified by ``$message`` if ``$array`` does not contains the ``$subset``.
-
-``$strict`` is a flag used to compare the identity of objects within arrays.
-
-.. code-block:: php
-    :caption: Usage of assertArraySubset()
-    :name: appendixes.assertions.assertArraySubset.example
-
-    <?php
-    use PHPUnit\Framework\TestCase;
-
-    class ArraySubsetTest extends TestCase
-    {
-        public function testFailure()
-        {
-            $this->assertArraySubset(['config' => ['key-a', 'key-b']], ['config' => ['key-a']]);
-        }
-    }
-
-.. parsed-literal::
-
-    $ phpunit ArraySubsetTest
-    PHPUnit |version|.0 by Sebastian Bergmann and contributors.
-
-    F
-
-    Time: 0 seconds, Memory: 5.00Mb
-
-    There was 1 failure:
-
-    1) Epilog\EpilogTest::testNoFollowOption
-    Failed asserting that an array has the subset Array &0 (
-        'config' => Array &1 (
-            0 => 'key-a'
-            1 => 'key-b'
-        )
-    ).
-
-    /home/sb/ArraySubsetTest.php:6
-
-    FAILURES!
-    Tests: 1, Assertions: 1, Failures: 1.
-
 .. _appendixes.assertions.assertClassHasStaticAttribute:
 
 assertClassHasStaticAttribute()


### PR DESCRIPTION
Based on the changelog of PHPUnit 9.0, the method has been removed, but it was still in the documentation.

Refs:
* https://github.com/sebastianbergmann/phpunit/blob/9.0.1/ChangeLog-9.0.md
* https://github.com/sebastianbergmann/phpunit/issues/3495

Note: I haven't tested with `make html` as that doesn't work on Windows :confused: 