### PR TITLE
PHPUnit 9.0: Update minimum supported PHP version

### DIFF
--- a/src/installation.rst
+++ b/src/installation.rst
@@ -11,7 +11,7 @@ Installing PHPUnit
 Requirements
 ############
 
-PHPUnit |version| requires PHP 7.2; using the latest version of PHP is highly
+PHPUnit |version| requires PHP 7.3; using the latest version of PHP is highly
 recommended.
 
 PHPUnit requires the `dom <http://php.net/manual/en/dom.setup.php>`_ and `json <http://php.net/manual/en/json.installation.php>`_


### PR DESCRIPTION
Based on the changelog of PHPUnit 9.0, support for PHP 7.2 was dropped.

Refs:
* https://github.com/sebastianbergmann/phpunit/blob/9.0.1/ChangeLog-9.0.md
* https://github.com/sebastianbergmann/phpunit/issues/3334

Note: I haven't tested with `make html` as that doesn't work on Windows :confused: 