### PR TITLE
PHPUnit 9.0: Replace references to `expectExceptionMessageRegExp()` with `expectExceptionMessageMatches()`

### DIFF
--- a/src/writing-tests-for-phpunit.rst
+++ b/src/writing-tests-for-phpunit.rst
@@ -651,7 +651,7 @@ whether an exception is thrown by the code under test.
 In addition to the ``expectException()`` method the
 ``expectExceptionCode()``,
 ``expectExceptionMessage()``, and
-``expectExceptionMessageRegExp()`` methods exist to set up
+``expectExceptionMessageMatches()`` methods exist to set up
 expectations for exceptions raised by the code under test.
 
 .. admonition:: Note


### PR DESCRIPTION
Based on the changelog of PHPUnit 9.0, the `expectExceptionMessageRegExp()` method has been removed and `expectExceptionMessageMatches()` should be used instead.

Refs:
* https://github.com/sebastianbergmann/phpunit/blob/9.0.1/ChangeLog-9.0.md
* https://github.com/sebastianbergmann/phpunit/issues/3957