### PR TITLE
Add missing backtick

### DIFF
--- a/src/assertions.rst
+++ b/src/assertions.rst
@@ -1035,7 +1035,7 @@ assertEqualsCanonicalizing()
 
 Reports an error identified by ``$message`` if the two variables ``$expected`` and ``$actual`` are not equal.
 
-The contents of ``$expected`` and ``$actual`` are canonicalized before they are compared. For instance, when the two variables ``$expected`` and ``$actual`` are arrays, then these arrays are sorted before they are compared. When `$expected`` and ``$actual`` are objects, each object is converted to an array containing all private, protected and public attributes.
+The contents of ``$expected`` and ``$actual`` are canonicalized before they are compared. For instance, when the two variables ``$expected`` and ``$actual`` are arrays, then these arrays are sorted before they are compared. When ``$expected`` and ``$actual`` are objects, each object is converted to an array containing all private, protected and public attributes.
 
 ``assertNotEqualsCanonicalizing()`` is the inverse of this assertion and takes the same arguments.
 


### PR DESCRIPTION
7.5 is the oldest branch that this fix applies to (the mistake was introduced in #151). Note that it won’t cleanly apply to master because the line was changed in the meantime (c47bb5fcfcb393146af5b95e9f023203bbfb577a). 6fa013a06b545d46b55dbaba532fd2bd5b04759e is a version of this commit against master (from before I read CONTRIBUTING.md and saw that it should be based on the oldest applicable branch), in case that’s useful.