### PR TITLE
Document missing <log> types

### DIFF
--- a/src/configuration.rst
+++ b/src/configuration.rst
@@ -222,14 +222,18 @@ logging of the test execution.
 .. code-block:: xml
 
     <logging>
-      <log type="coverage-html" target="/tmp/report" lowUpperBound="35"
+      <log type="coverage-html" target="/tmp/report/html" lowUpperBound="35"
            highLowerBound="70"/>
-      <log type="coverage-clover" target="/tmp/coverage.xml"/>
-      <log type="coverage-php" target="/tmp/coverage.serialized"/>
+      <log type="coverage-xml" target="tmp/report/xml"/>
+      <log type="coverage-clover" target="/tmp/coverage.clover.xml"/>
+      <log type="coverage-crap4j" target="/tmp/coverage.crap4j.xml"/>
+      <log type="coverage-php" target="/tmp/coverage.serialized.php"/>
       <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
       <log type="junit" target="/tmp/logfile.xml"/>
+      <log type="teamcity" target="/tmp/teamcity.txt"/>
       <log type="testdox-html" target="/tmp/testdox.html"/>
       <log type="testdox-text" target="/tmp/testdox.txt"/>
+      <log type="testdox-xml" target="/tmp/testdox.xml"/>
     </logging>
 
 The XML configuration above corresponds to invoking the TextUI test runner
@@ -237,15 +241,23 @@ with the following options:
 
 -
 
-  ``--coverage-html /tmp/report``
+  ``--coverage-html /tmp/report/html``
 
 -
 
-  ``--coverage-clover /tmp/coverage.xml``
+  ``--coverage-xml /tmp/report/xml``
 
 -
 
-  ``--coverage-php /tmp/coverage.serialized``
+  ``--coverage-clover /tmp/coverage.clover.xml``
+
+-
+
+  ``--coverage-crap4j /tmp/coverage.crap4j.xml``
+
+-
+
+  ``--coverage-php /tmp/coverage.serialized.php``
 
 -
 
@@ -261,11 +273,19 @@ with the following options:
 
 -
 
+  ``--log-teamcity /tmp/teamcity.txt``
+
+-
+
   ``--testdox-html /tmp/testdox.html``
 
 -
 
   ``--testdox-text /tmp/testdox.txt``
+
+-
+
+  ``--testdox-xml /tmp/testdox.xml``
 
 The ``lowUpperBound``, ``highLowerBound``,
 and ``showUncoveredFiles`` attributes have no equivalent TextUI


### PR DESCRIPTION
Hello @sebastianbergmann 

I've been working on sebastianbergmann/php-code-coverage#380, and while testing my work have noticed that the documentation for PHPUnit's XML config doesn't include all of the possible logging types, so please find attached a PR to do that.

Your contributing guidelines say to attach a PR for the lowest affected version, but I wasn't sure which one to pick - there is still a branch here for 7.0, even though I know you don't support PHPUnit 7 itself anymore. Please let me know if you would like a different branch targeted 😅 