### PR TITLE
Update uncovered files configuration settings

### DIFF
--- a/src/code-coverage-analysis.rst
+++ b/src/code-coverage-analysis.rst
@@ -100,20 +100,20 @@ This can either be done using the ``--coverage-filter``
 :ref:`command line <textui.clioptions>` option or via the
 configuration file (see :ref:`appendixes.configuration.coverage.include`).
 
-The ``includeUncoveredFilesInCodeCoverageReport`` and ``processUncoveredFilesForCodeCoverageReport`` configuration settings are available to configure how the filter is used:
+The ``includeUncoveredFiles` and ``processUncoveredFiles`` configuration settings are available to configure how the filter is used:
 
-- ``includeUncoveredFilesInCodeCoverageReport="false"`` means that only files that have at least one line of executed code are included in the code coverage report
+- ``includeUncoveredFiles="false"`` means that only files that have at least one line of executed code are included in the code coverage report
 
-- ``includeUncoveredFilesInCodeCoverageReport="true"`` (default) means that all files are included in the code coverage report even if not a single line of code of such a file is executed
+- ``includeUncoveredFiles="true"`` (default) means that all files are included in the code coverage report even if not a single line of code of such a file is executed
 
-- ``processUncoveredFilesForCodeCoverageReport="false"`` (default) means that a file that has no executed lines of code will be added to the code coverage report (if ``includeUncoveredFilesInCodeCoverageReport="true"`` is set) but it will not be loaded by PHPUnit and it will therefore not be analysed for correct executable lines of code information
+- ``processUncoveredFiles="false"`` (default) means that a file that has no executed lines of code will be added to the code coverage report (if ``includeUncoveredFiles="true"`` is set) but it will not be loaded by PHPUnit and it will therefore not be analysed for correct executable lines of code information
 
-- ``processUncoveredFilesForCodeCoverageReport="true"`` means that a file that has no executed lines of code will be loaded by PHPUnit so that it can be analysed for correct executable lines of code information
+- ``processUncoveredFiles="true"`` means that a file that has no executed lines of code will be loaded by PHPUnit so that it can be analysed for correct executable lines of code information
 
 .. admonition:: Note
 
    Please note that the loading of sourcecode files that is performed when
-   ``processUncoveredFilesForCodeCoverageReport="true"`` is set can
+   ``processUncoveredFiles="true"`` is set can
    cause problems when a sourcecode file contains code outside the scope of
    a class or function, for instance.
 

--- a/src/code-coverage-analysis.rst
+++ b/src/code-coverage-analysis.rst
@@ -100,7 +100,7 @@ This can either be done using the ``--coverage-filter``
 :ref:`command line <textui.clioptions>` option or via the
 configuration file (see :ref:`appendixes.configuration.coverage.include`).
 
-The ``includeUncoveredFiles` and ``processUncoveredFiles`` configuration settings are available to configure how the filter is used:
+The ``includeUncoveredFiles`` and ``processUncoveredFiles`` configuration settings are available to configure how the filter is used:
 
 - ``includeUncoveredFiles="false"`` means that only files that have at least one line of executed code are included in the code coverage report
 


### PR DESCRIPTION
`includeUncoveredFilesInCodeCoverageReport` and `processUncoveredFilesInCodeCoverageReport` appear to have been renamed to simply `includeUncoveredFiles` and `processUncoveredFiles` as of PHPUnit 9.3 (ref: https://github.com/sebastianbergmann/phpunit/commit/c1fde6d1fc18e1171bf212141b8def045883c9f6).

This updates the documentation to use those shorter names.