### PR TITLE
Skipping tests: clarify behaviour with multiple `@requires` tags

### DIFF
--- a/src/incomplete-and-skipped-tests.rst
+++ b/src/incomplete-and-skipped-tests.rst
@@ -190,6 +190,9 @@ Skipping Tests using @requires
 In addition to the above methods it is also possible to use the
 ``@requires`` annotation to express common preconditions for a test case.
 
+A test can have multiple ``@requires`` annotations, in which case all requirements
+need to be met for the test to run.
+
 .. rst-class:: table
 .. list-table:: Possible @requires usages
     :name: incomplete-and-skipped-tests.requires.tables.api


### PR DESCRIPTION
Found myself testing whether this was supported, so figured it might be useful to add this information to the manual.