### PR TITLE
Effect of `tearDown` on garbage collection

### DIFF
--- a/src/fixtures.rst
+++ b/src/fixtures.rst
@@ -190,11 +190,14 @@ symmetrical in theory but not in practice. In practice, you only need
 to implement ``tearDown()`` if you have allocated
 external resources like files or sockets in ``setUp()``.
 If your ``setUp()`` just creates plain PHP objects, you
-can generally ignore ``tearDown()``. However, if you
+can generally ignore ``tearDown()``. 
+
+However, if you
 create many objects in your ``setUp()``, you might want
 to ``unset()`` the variables pointing to those objects
 in your ``tearDown()`` so they can be garbage collected.
-The garbage collection of test case objects is not predictable.
+Test case objects created within ``setUp()`` are only automatically garbage 
+collected at the end of PHPUnit's execution, or per test when the "Process Isolation" option is used.
 
 .. _fixtures.variations:
 


### PR DESCRIPTION
While tracking down a memory leak during a phpunit run I've found that this section is probably out of date (atleast for 8.5 and 9.5). As far as I can find out through the source there is no mechanism to clean up testcases which have already been completed. Maybe this used to be different in the past, and PHP's GC being what it used to be resulted in the "not predictable" description being used in the previous version.

I think the current behaviour may also be the cause of various reports about memory leaks within PHPUnit. Improving the documentation is a start, though maybe the behaviour itself can be improved.

For additional clarification, this is a testcase with a commented out portion which would have to be implemented to avoid a leak
```
final class MemoryTest extends TestCase {
    private array $large;

    protected function setUp(): void {
        $this->large = array_fill(0, 100000, "Data");
    }

    /**
     * @dataProvider getCases
     * @param int $i
     */
    public function testMemory(int $i): void {
        $this->assertIsArray($this->large);
        echo sprintf("\n%.1fMB", memory_get_usage(true) / 1e6);
    }

    public function getCases() {
        for ($i = 0; $i < 100; ++$i) {
            yield [ $i ];
        }
    }

//    protected function tearDown(): void {
//        unset($this->large);
//    }
}
```