### PR TITLE
Fix typo in code example

### DIFF
--- a/src/extending-phpunit.rst
+++ b/src/extending-phpunit.rst
@@ -182,7 +182,7 @@ definition to the extension class:
 
         public function executeBeforeFirstTest(): void
         {
-            if (strlen($this-config_value_1) {
+            if (strlen($this->config_value_1) {
                 echo 'Testing with configuration value: ' . $this->config_value_1;
             }
         }


### PR DESCRIPTION
Continuation of #187, which was closed because the `7.2` branch was deleted, but the typo is still there.