### PR TITLE
test doubles: stubs: list available short hands

### DIFF
--- a/src/test-doubles.rst
+++ b/src/test-doubles.rst
@@ -182,9 +182,32 @@ the same best practice defaults used by ``createStub()``.
     }
 
 In the examples so far we have been returning simple values using
-``willReturn($value)``. This short syntax is the same as
-``will($this->returnValue($value))``. We can use variations
-on this longer syntax to achieve more complex stubbing behaviour.
+``willReturn($value)`` – a short syntax for convenience. :numref:`test-doubles.stubs.shorthands` shows the
+available stubbing short hands alongside their longer counterparts.
+
+.. rst-class:: table
+.. list-table:: Stubbing short hands
+    :name: test-doubles.stubs.shorthands
+    :header-rows: 1
+
+    * - short hand
+      - longer syntax
+    * - ``willReturn($value)``
+      - ``will($this->returnValue($value))``
+    * - ``willReturnArgument($argumentIndex)``
+      - ``will($this->returnArgument($argumentIndex))``
+    * - ``willReturnCallback($callback)``
+      - ``will($this->returnCallback($callback))``
+    * - ``willReturnMap($valueMap)``
+      - ``will($this->returnValueMap($valueMap))``
+    * - ``willReturnOnConsecutiveCalls($value1, $value2)``
+      - ``will($this->onConsecutiveCalls($value1, $value2))``
+    * - ``willReturnSelf()``
+      - ``will($this->returnSelf())``
+    * - ``willThrowException($exception)``
+      - ``will($this->throwException($exception))``
+
+We can use variations on this longer syntax to achieve more complex stubbing behaviour.
 
 Sometimes you want to return one of the arguments of a method call
 (unchanged) as the result of a stubbed method call.


### PR DESCRIPTION
List the (convenience) short hands and their longer counterparts.

IDEs should do a fine job suggesting those already, but having them
show up on readthedocs would be great.

Maybe it would make more sense to only mention the short hands after
their long syntax is explained (as happens for quite a few of them
in the paragraphs thereafter), but I placed the list of available
short hands where it was explained for `willReturn($value)` so far.

Long call syntax as seen in https://github.com/sebastianbergmann/phpunit-mock-objects/blob/0dfddc236629eb7ead4df2dfa3d79d548e011a3b/tests/MockObjectTest.php

Resolves #20