### PR TITLE
Fix to short headline underline

### DIFF
--- a/src/configuration.rst
+++ b/src/configuration.rst
@@ -216,7 +216,7 @@ This attribute configures whether the test suite execution should be stopped aft
 .. _appendixes.configuration.phpunit.failOnIncomplete:
 
 The ``failOnIncomplete`` Attribute
------------------------------
+----------------------------------
 
 Possible values: ``true`` or ``false`` (default: ``false``)
 
@@ -234,7 +234,7 @@ This attribute configures whether the PHPUnit test runner should exit with a she
 .. _appendixes.configuration.phpunit.failOnSkipped:
 
 The ``failOnSkipped`` Attribute
------------------------------
+-------------------------------
 
 Possible values: ``true`` or ``false`` (default: ``false``)
 


### PR DESCRIPTION
This removes the warning triggered while rendering.