### PR TITLE
Add missing equal sign to --colors command line option

### DIFF
--- a/src/textui.rst
+++ b/src/textui.rst
@@ -130,7 +130,7 @@ the following code:
       --globals-backup            Backup and restore $GLOBALS for each test
       --static-backup             Backup and restore static attributes for each test
 
-      --colors <flag>             Use colors in output ("never", "auto" or "always")
+      --colors=<flag>             Use colors in output ("never", "auto" or "always")
       --columns <n>               Number of columns to use for progress output
       --columns max               Use maximum number of columns for progress output
       --stderr                    Write to STDERR instead of STDOUT


### PR DESCRIPTION
The provided value will only be recognized when combined with equal
sign.
Errors might be thrown depending on concrete position when used without
equal sign.

Resolves: #219