### PR TITLE
Update XML printerClass default value

### DIFF
--- a/src/configuration.rst
+++ b/src/configuration.rst
@@ -130,9 +130,9 @@ This attribute configures whether a test will be marked as risky (see :ref:`risk
 The ``printerClass`` Attribute
 ------------------------------
 
-Default: ``PHPUnit\TextUI\ResultPrinter``
+Default: ``PHPUnit\TextUI\DefaultResultPrinter``
 
-This attribute configures the name of a class that either is ``PHPUnit\TextUI\ResultPrinter`` or that extends ``PHPUnit\TextUI\ResultPrinter``. An object of this class is used to print progress and test results.
+This attribute configures the name of a class that implements the ``PHPUnit\TextUI\ResultPrinter`` interface. An object of this class is used to print progress and test results.
 
 .. _appendixes.configuration.phpunit.printerFile:
 


### PR DESCRIPTION
Minor update to the XML configuration section of the documentation for the `printerClass` attribute. The `ResultPrinter` class was changed to be an interface and the default printer class updated to `DefaultResultPrinter` in the code and the XSD (Here is the PR that this update was made in for reference https://github.com/sebastianbergmann/phpunit/issues/4024).

In addition to updating the Default value for `printerClass` in the docs I've updated the description to refer to it as an interface and have made the wording consistent with the description of the `testSuiteLoaderClass` which also has an interface and standard class.

Looking through PHPUnit it appears that the first version of the code to convert the class `ResultPrinter` to an interface was PHPUnit 9.0.0 which is why I have opened this PR to only be merged into branch 9.5.