### PR TITLE
Document Unicode behavior of string assertion

### DIFF
--- a/src/assertions.rst
+++ b/src/assertions.rst
@@ -175,7 +175,9 @@ assertStringContainsStringIgnoringCase()
 
 Reports an error identified by ``$message`` if ``$needle`` is not a substring of ``$haystack``.
 
-Differences in casing are ignored when ``$needle`` is searched for in ``$haystack``.
+Differences in casing are ignored when ``$needle`` is searched for in ``$haystack``. This also works 
+for unicode characters with diacritics (accents, umlaut, circumflex, etc.) as long as both strings 
+have the same `Normalization Form <https://www.php.net/manual/en/class.normalizer.php>`_.
 
 ``assertStringNotContainsStringIgnoringCase()`` is the inverse of this assertion and takes the same arguments.
 


### PR DESCRIPTION
Internally the `assertStringContainsString` and `assertStringContainsStringIgnoringCase` use unicode-aware `mb_` functions. This behavior might become interesting, when dealing with different representations of Unicode strings:

```php
// NFC and NFD representations of "ü"
$ue_composed="\xC3\xBC";
$ue_decomposed="\x75\xCC\x88";
$haystack_composed="\xC3\x9Cberraschung!"
// Both assertions will pass
$this->assertStringContainsStringIgnoringCase($ue_composed, $haystack);
$this->assertStringNotContainsStringIgnoringCase($ue_decomposed, $haystack);
```