### PR TITLE
Update default value of convertDeprecationsToExceptions

### DIFF
--- a/src/configuration.rst
+++ b/src/configuration.rst
@@ -96,7 +96,7 @@ If ``max`` is defined as value, the number of columns will be maximum of the cur
 The ``convertDeprecationsToExceptions`` Attribute
 -------------------------------------------------
 
-Possible values: ``true`` or ``false`` (default: ``true``)
+Possible values: ``true`` or ``false`` (default: ``false``)
 
 This attribute configures whether ``E_DEPRECATED`` and ``E_USER_DEPRECATED`` events triggered by the code under test are converted to an exception (and mark the test as error).
 


### PR DESCRIPTION
The default was changed in https://github.com/sebastianbergmann/phpunit/commit/fac02620f6b38ae54d47fe840e0095e68226a56c - the docs just don't reflect that yet.


I updated/rebased the change on `8.5` as per contribution guideline to target the oldest branch the change was ported to. 