### PR TITLE
Remove repeat option from options on textui

### DIFF
--- a/src/textui.rst
+++ b/src/textui.rst
@@ -144,8 +144,6 @@ the following code:
       --fail-on-skipped                Treat skipped tests as failures
       --fail-on-warning                Treat tests with warnings as failures
 
-      --repeat <times>                 Runs the test(s) repeatedly
-
       --cache-result                   Write test results to cache file
       --do-not-cache-result            Do not write test results to cache file
 
@@ -457,10 +455,6 @@ the following code:
 
     Output more verbose information, for instance the names of tests
     that were incomplete or have been skipped.
-
-``--repeat``
-
-    Repeatedly runs the test(s) the specified number of times.
 
 ``--testdox``
 


### PR DESCRIPTION
This removes the repeat option from the list of options for phpunit 10 - as removed in [commit 442b9a](https://github.com/sebastianbergmann/phpunit/commit/442b9ab7e0aa8a1fc7d93d2f0388e29869460202).