### PR TITLE
Remove unused import in Mock Objects SUT example

### DIFF
--- a/src/test-doubles.rst
+++ b/src/test-doubles.rst
@@ -447,7 +447,6 @@ classes that are part of the System under Test (SUT).
     :name: test-doubles.mock-objects.examples.SUT.php
 
     <?php declare(strict_types=1);
-    use PHPUnit\Framework\TestCase;
 
     class Subject
     {


### PR DESCRIPTION
Remove line:
`use PHPUnit\Framework\TestCase;` that is in the example, but not referenced.