### PR TITLE
Enhancement: Add documentation for `assertObjectHasProperty()`

### DIFF
--- a/src/assertions.rst
+++ b/src/assertions.rst
@@ -398,6 +398,29 @@ Running the test shown above yields the output shown below:
 
 .. _appendixes.assertions.cardinality:
 
+Objects
+========
+
+.. _appendixes.assertions.assertObjectHasProperty:
+
+``assertObjectHasProperty()``
+-----------------------------
+
+``assertObjectHasProperty(string $propertyName, object $object, string $message = '')``
+
+Reports an error identified by ``$message`` if ``$object`` does not have a property with the name ``$propertyName``.
+
+``assertObjectNotHasProperty()`` is the inverse of this assertion and takes the same arguments.
+
+.. literalinclude:: examples/assertions/ObjectHasPropertyTest.php
+   :caption: Usage of assertObjectHasProperty()
+   :language: php
+
+Running the test shown above yields the output shown below:
+
+.. literalinclude:: examples/assertions/ObjectHasPropertyTest.php.out
+
+
 Cardinality
 ===========
 

--- a/src/examples/assertions/ObjectHasPropertyTest.php
+++ b/src/examples/assertions/ObjectHasPropertyTest.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+use PHPUnit\Framework\TestCase;
+
+final class ObjectHasPropertyTest extends TestCase
+{
+    public function testFailure(): void
+    {
+        $this->assertObjectHasProperty('propertyName', new stdClass);
+    }
+}

--- a/src/examples/assertions/ObjectHasPropertyTest.php.out
+++ b/src/examples/assertions/ObjectHasPropertyTest.php.out
@@ -1,0 +1,18 @@
+./tools/phpunit tests/ObjectHasPropertyTest.php
+PHPUnit 10.1-dev by Sebastian Bergmann and contributors.
+
+Runtime:       PHP 8.1.17
+
+F                                                                   1 / 1 (100%)
+
+Time: 00:00, Memory: 22.34 MB
+
+There was 1 failure:
+
+1) ObjectHasPropertyTest::testFailure
+Failed asserting that object of class "stdClass" has property "propertyName".
+
+/path/to/tests/ObjectHasPropertyTest.php:8
+
+FAILURES!
+Tests: 1, Assertions: 1, Failures: 1.


### PR DESCRIPTION
This pull request

- [x] adds documentation for `assertObjectHasProperty()`

Fixes #290.