### PR TITLE
Fix: Order

### DIFF
--- a/src/code-coverage.rst
+++ b/src/code-coverage.rst
@@ -26,7 +26,7 @@ extensions for PHP.
 
    If you see a warning while running tests that no code coverage driver is
    available, it means that you are using the PHP CLI binary (``php``) and do not
-   have Xdebug or PCOV loaded.
+   have PCOV or Xdebug loaded.
 
 .. admonition:: Note
 


### PR DESCRIPTION
This pull request 

- [x] uses a consistent order for mentions of PCOV and Xdebug