### PR TITLE
Fix PHP attribute syntax error in example

### DIFF
--- a/src/code-coverage.rst
+++ b/src/code-coverage.rst
@@ -139,8 +139,8 @@ shows an example.
     use PHPUnit\Framework\Attributes\UsesClass;
     use PHPUnit\Framework\TestCase;
 
-    #[CoversClass Invoice::class]
-    #[UsesClass Money::class]
+    #[CoversClass(Invoice::class)]
+    #[UsesClass(Money::class)]
     final class InvoiceTest extends TestCase
     {
         public function testAmountInitiallyIsEmpty(): void


### PR DESCRIPTION
* [Attribute](https://www.php.net/manual/en/language.attributes.syntax.php) syntax was not correct.