### PR TITLE
fix: docs of @postCondition

### DIFF
--- a/src/attributes.rst
+++ b/src/attributes.rst
@@ -771,7 +771,7 @@ This is equivalent to naming the method ``assertPreConditions()``.
 +------------+-------------+--------------+------------+
 
 The ``PostCondition`` attribute can be used to specify that a protected non-static method should
-be invoked before each test method (but before any ``tearDown()`` methods) of a test case class is run.
+be invoked after each test method (but before any ``tearDown()`` methods) of a test case class is run.
 This is equivalent to naming the method ``assertPostConditions()``.
 
 


### PR DESCRIPTION
If I understand correctly how it works (but I may be wrong), the method marked with `@postCondition` will be called after the test.