### PR TITLE
docs(configruation): Add testsuite tag to directory and file element

### DIFF
--- a/src/configuration.rst
+++ b/src/configuration.rst
@@ -606,7 +606,7 @@ The example shown above instructs PHPUnit to include all sourcecode files with `
 The ``<directory>`` Element
 ---------------------------
 
-Parent elements: ``<include>``, ``<exclude>``
+Parent elements: ``<include>``, ``<exclude>``, ``<testsuite>``
 
 Configures a directory and its sub-directories for inclusion in or exclusion from code coverage report(s).
 
@@ -644,7 +644,7 @@ Configures the comparison operator to be used with ``version_compare()`` for the
 The ``<file>`` Element
 ----------------------
 
-Parent elements: ``<include>``, ``<exclude>``
+Parent elements: ``<include>``, ``<exclude>``, ``<testsuite>``
 
 Configures a file for inclusion in or exclusion from code coverage report(s).
 


### PR DESCRIPTION
As far is I understood `file` and `directory` can also be used in `testsuite`. Added for consistency.

In version 9.5 the seperate `<file>` and `<directory>` chapters were added.

Thank you for the very accurate documentation. That just helps a lot for edgcases. 👏