### PR TITLE
Fix typo in fixtures note

### DIFF
--- a/src/fixtures.rst
+++ b/src/fixtures.rst
@@ -253,7 +253,7 @@ to exclude specific static properties from the backup and restore operations for
 
 .. admonition:: Note
 
-   The the backup operation for static properties of classes is performed before a test method,
+   The backup operation for static properties of classes is performed before a test method,
    but only if it is enabled. If a static value was changed by a previously executed test that
    did not have ``BackupStaticProperties(true)``, then that value will be backed up and restored —
    not the originally declared default value.


### PR DESCRIPTION
PR removes an extraneous `the` from a note at the bottom of the Fixtures page. This typo exists across versions, so could probably be applied to the various branches to fix the docs for those versions?