### PR TITLE
fix param order in addition test

### DIFF
--- a/src/attributes.rst
+++ b/src/attributes.rst
@@ -117,7 +117,7 @@ may use the method parameters as placeholders in your alternative description.
     {
         #[DataProvider('additionProvider')]
         #[TestDox('Adding $a to $b results in $expected')]
-        public function testAdd(int $expected, int $a, int $b)
+        public function testAdd(int $a, int $b, int $expected)
         {
             $this->assertSame($expected, $a + $b);
         }


### PR DESCRIPTION
The order of the data seems to be a,b,expected, but the parameter order in the tests is different.