### PR TITLE
rename in dir structure: phive.xml => .phive/phars.xml

### DIFF
--- a/src/installation.rst
+++ b/src/installation.rst
@@ -322,7 +322,8 @@ After executing the command shown above the project's directory will look like t
 
 .. code::
 
-    ├── phive.xml
+    ├── .phive
+    |   └── phars.xml
     ├── public
     ├── src
     ├── tests
@@ -369,7 +370,8 @@ After executing the command shown above the project's directory will look like t
 
 .. code::
 
-    ├── phive.xml
+    ├── .phive
+    |   └── phars.xml
     ├── public
     ├── src
     ├── tests


### PR DESCRIPTION
In phive docu, rename the dir structure contents from `phive.xml` to `.phive/phars.xml`,
as I *think* the `phive.xml` comes from an older phive version.