### PR TITLE
fix symbolic link cmd arguments

### DIFF
--- a/src/installation.rst
+++ b/src/installation.rst
@@ -381,7 +381,7 @@ After executing the command shown above the project's directory will look like t
 .. admonition:: Note
 
     Unfortunately, PhpStorm only recognizes a file as a PHP archive when it has the ``.phar`` suffix.
-    This is remedied by creating a symbolic link: ``ln -s phpunit tools/phpunit.phar``.
+    This is remedied by creating a symbolic link: ``ln -s tools/phpunit phpunit.phar``.
 
 Updating PHPUnit with Phive
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
I believe that in order to create a symbolic link `./phpunit.phar` (for PHPStorm) pointing to the source `./tools/phpunit`, the documentation needs to be fixed as it is not correct.