### PR TITLE
Fix macOS installation instructions

### DIFF
--- a/src/installation.rst
+++ b/src/installation.rst
@@ -119,6 +119,13 @@ If you want to collect code coverage information, you need to additionally insta
 - ``pcov``
 - ``xdebug``
 
+To install these extensions, we need the `homebrew-extensions formulae <https://github.com/shivammathur/homebrew-extensions>`_.
+The following command will fetch these formulae:
+
+.. code::
+
+    brew tap shivammathur/extensions
+
 The following command will install and enable the ``pcov`` extension:
 
 .. code::


### PR DESCRIPTION
There are no formulae with names pcov and xdebug

```
➜  ~ brew tap shivammathur/php            
➜  ~ brew install shivammathur/php/php@8.2
Warning: shivammathur/php/php@8.2 8.2.27 is already installed and up-to-date.
To reinstall 8.2.27, run:
  brew reinstall php@8.2
➜  ~ brew install pcov@8.2
Warning: No available formula with the name "pcov@8.2".
==> Searching for similarly named formulae and casks...
Error: No formulae or casks found for pcov@8.2.
➜  ~ brew install xdebug@8.2
Warning: No available formula with the name "xdebug@8.2".
==> Searching for similarly named formulae and casks...
Error: No formulae or casks found for xdebug@8.2.
➜  ~ 
```

I suppose it should be pecl install, not brew
