### PR TITLE
Add anchors for failOnPhpunitDeprecation and displayDetailsOnPhpunitDeprecations

### DIFF
--- a/src/configuration.rst
+++ b/src/configuration.rst
@@ -266,6 +266,8 @@ Possible values: ``true`` or ``false`` (default: ``false``)
 
 This attribute configures whether the PHPUnit test runner should exit with a shell exit code that indicates failure when all tests are successful but there are tests that triggered a deprecation (``E_DEPRECATED`` or ``E_USER_DEPRECATED``).
 
+.. _appendixes.configuration.phpunit.failOnPhpunitDeprecation:
+
 The ``failOnPhpunitDeprecation`` Attribute
 ------------------------------------------
 
@@ -512,6 +514,8 @@ The ``displayDetailsOnTestsThatTriggerDeprecations`` Attribute
 Possible values: ``true`` or ``false`` (default: ``false``)
 
 This attribute configures whether details on tests that triggered deprecations should be printed.
+
+.. _appendixes.configuration.phpunit.displayDetailsOnPhpunitDeprecations:
 
 The ``displayDetailsOnPhpunitDeprecations`` Attribute
 -----------------------------------------------------


### PR DESCRIPTION
fix https://github.com/sebastianbergmann/phpunit-documentation-english/commit/41897950fa4c4f6a667869d1c47ed85d2ef4b4ec

I noticed when making https://github.com/sebastianbergmann/phpunit-documentation-english/pull/408 , that maybe the anchors were forgotten.