### PR TITLE
document the --display-phpunit-notices option

### DIFF
--- a/src/error-handling.rst
+++ b/src/error-handling.rst
@@ -81,8 +81,7 @@ Shown below is the default output PHPUnit's test runner prints for the example s
     OK, but there were issues!
     Tests: 2, Assertions: 2, Deprecations: 2.
 
-Detailed information, for instance which issue was triggered where, is only printed when ``--display-deprecations``,
-``--display-notices``, or ``--display-warnings`` is used:
+Detailed information, for instance which issue was triggered where, is only printed when ``--display-deprecations``, ``--display-notices``, ``--display-warnings``, or ``--display-all-issues``` is used:
 
 .. parsed-literal::
 

--- a/src/textui.rst
+++ b/src/textui.rst
@@ -473,6 +473,10 @@ Details about Issues
 
     Display details for PHPUnit deprecations.
 
+``--display-phpunit-notices``
+
+    Display details for PHPUnit notices.
+
 ``--display-errors``
 
     Display details for errors triggered by tests.


### PR DESCRIPTION
I ran into this discrepancy when my boss asked me why he wasn't seeing the expected output on a bunch of `NNNN` tests. After a bit of digging it became obvious he was seeing PHPUnit notices, not PHP notices. `--display-all-issues` did show them, but the actual option he wanted was only documented in the CLI `--help` output. So... adding it to the documentation.